### PR TITLE
Add crash handler for unhandled exceptions before app startup

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -150,9 +150,15 @@ jobs:
         with:
           name: fe
           path: ./publish/web
+      # vpk builds the Setup.exe / Update.exe binaries that the Velopack NuGet package talks
+      # to, and Velopack ships both halves under one version number — they are meant to match.
+      # Unpinned, this step silently took whatever was newest, so the installer version drifted
+      # from the library on its own schedule and every build was a different pair. Pinned to the
+      # version releases are already being cut with; raising it means raising the Velopack
+      # PackageReference in lockstep.
       - name: Install Velopack CLI
         if: matrix.runtimeMode == 'WINFORMS' || matrix.runtimeMode == 'MACOS'
-        run: dotnet tool install -g vpk
+        run: dotnet tool install -g vpk --version 1.2.0
       - name: Determine Velopack channel
         if: matrix.runtimeMode == 'WINFORMS' || matrix.runtimeMode == 'MACOS'
         id: vpk-channel

--- a/src/apps/Bakabase/Components/CrashHandler.cs
+++ b/src/apps/Bakabase/Components/CrashHandler.cs
@@ -1,0 +1,83 @@
+using System;
+using System.Threading.Tasks;
+
+namespace Bakabase.Components;
+
+/// <summary>
+/// Last-resort reporting for exceptions that nothing else catches.
+///
+/// <c>AppHost.Start</c> already wraps its own body in a try/catch that logs and raises the
+/// fatal-error window, so anything failing in there is both visible and recorded. The window
+/// before it is neither: a throw in Avalonia's XAML load, in <c>App.Initialize</c>'s tray-icon
+/// resolution, in the pending data-path relocation, or in <c>AppService</c>'s static
+/// constructor ends the process with no window and no log line. That is precisely the "it
+/// closes the instant I open it" report we cannot act on — the exception exists only in the
+/// OS event log, which users do not think to open and we cannot walk every one of them
+/// through.
+///
+/// Sentry is deliberately not called from here. <c>SentrySdk.Init</c> (see
+/// <c>BakabaseStartup.ConfigureServices</c>) installs its own unhandled-exception integration,
+/// so capturing again would duplicate every event it can already see; and before that init
+/// runs there is no transport to send on anyway. What this class adds is the two sinks Sentry
+/// cannot cover: the file log, and stderr.
+/// </summary>
+internal static class CrashHandler
+{
+    public static void Install()
+    {
+        AppDomain.CurrentDomain.UnhandledException += (_, e) =>
+            Report(e.ExceptionObject as Exception, e.ExceptionObject, "Unhandled exception",
+                e.IsTerminating);
+
+        // Left unobserved on purpose: since .NET 4.5 these do not terminate the process, so
+        // calling SetObserved would change nothing today while quietly disarming the escalation
+        // if ThrowUnobservedTaskExceptions is ever switched on. We only want them in the log.
+        TaskScheduler.UnobservedTaskException += (_, e) =>
+            Report(e.Exception, e.Exception, "Unobserved task exception", terminating: false);
+    }
+
+    /// <param name="detail">
+    /// <c>UnhandledException</c> hands us <c>object</c>, not <c>Exception</c> — a throw from
+    /// another language on the same runtime need not be one. Rendering it separately keeps
+    /// those cases from being reported as an empty line.
+    /// </param>
+    private static void Report(Exception? exception, object? detail, string what, bool terminating)
+    {
+        // The two sinks get their own guard rather than sharing one: a console handle that
+        // rejects writes must not be able to cost us the log entry, which is the sink that
+        // actually reaches users.
+        try
+        {
+            // Unconditional, and first. It is the only sink that works before the Serilog file
+            // sink exists, and `Bakabase.exe 2> crash.txt` from a console is the one instruction
+            // we can give a user whose app dies before it can write anywhere.
+            Console.Error.WriteLine($"[Bakabase] {what}: {detail}");
+        }
+        catch
+        {
+            // No console to write to. The log below is the one that matters anyway.
+        }
+
+        try
+        {
+            // Silently discarded until AppService's static constructor has built the file sink
+            // (Serilog's default logger is a no-op). Program.Main forces that to happen before
+            // Avalonia starts, so in practice this lands in {AppData}/logs/AppLog_*.log right
+            // after the startup trace that shows how far the launch got.
+            Serilog.Log.Fatal(exception, "{What} (terminating: {Terminating}) {Detail}", what,
+                terminating, exception == null ? detail : null);
+
+            if (terminating)
+            {
+                // The file sink is unbuffered, so this is belt-and-braces — but the process is
+                // about to die either way, and a truncated final entry is the one we need most.
+                Serilog.Log.CloseAndFlush();
+            }
+        }
+        catch
+        {
+            // A crash reporter that throws turns a diagnosable crash into a mystery. There is
+            // nowhere left to report this to, so drop it.
+        }
+    }
+}

--- a/src/apps/Bakabase/Program.cs
+++ b/src/apps/Bakabase/Program.cs
@@ -1,4 +1,6 @@
 using Avalonia;
+using Bakabase.Components;
+using Bakabase.Infrastructures.Components.App;
 using Bakabase.Infrastructures.Components.App.Upgrade;
 using Velopack;
 
@@ -27,6 +29,20 @@ class Program
             .SetAutoApplyOnStartup(false)
             .SetLogger(new SerilogVelopackLogger())
             .Run();
+
+        // Everything from here on can be reported. Velopack's hook invocations never reach this
+        // line (Run ends in Environment.Exit for them), so installing the handler after it costs
+        // no coverage of a real launch.
+        CrashHandler.Install();
+
+        // Touching AppService runs its static constructor, which is what builds the Serilog file
+        // sink. That would otherwise happen a step later, inside OnFrameworkInitializationCompleted
+        // — leaving Avalonia's XAML load and tray-icon resolution in a window where a throw is
+        // recorded nowhere but the OS event log. Pulling it forward changes only when this work
+        // runs, not what it does: OnFrameworkInitializationCompleted's first act is to read the
+        // same property. Deliberately not guarded — the static ctor throws by design when the
+        // AppData layout cannot be migrated, and the handler above is already armed to report it.
+        _ = AppService.DefaultAppDataDirectory;
 
         BuildAvaloniaApp()
             .StartWithClassicDesktopLifetime(args);


### PR DESCRIPTION
## Summary

Adds a last-resort crash handler to capture and log exceptions that occur before the main application window can display, ensuring critical startup failures are recorded in both stderr and the application log file rather than silently disappearing into the OS event log.

## Changes

- **New `CrashHandler` component** (`src/apps/Bakabase/Components/CrashHandler.cs`):
  - Installs handlers for `AppDomain.UnhandledException` and `TaskScheduler.UnobservedTaskException`
  - Logs exceptions to both stderr (for console capture) and Serilog file sink (for persistent logs)
  - Gracefully handles failures in the crash reporting itself to avoid masking the original exception
  - Deliberately avoids calling Sentry to prevent duplication with its own unhandled-exception integration

- **Updated `Program.Main`** to install the crash handler and eagerly initialize `AppService`:
  - Installs `CrashHandler` immediately after Velopack setup completes
  - Touches `AppService.DefaultAppDataDirectory` to force its static constructor to run before Avalonia starts, ensuring the Serilog file sink exists before XAML loading or tray-icon resolution can fail
  - Adds detailed comments explaining the timing and rationale

- **Pinned Velopack CLI version** in build workflow (`_build.yml`):
  - Locks `vpk` to version 1.2.0 to match the Velopack NuGet package version
  - Prevents silent version drift between installer binaries and the library

## Implementation Details

The handler is installed after Velopack's hooks complete (which never reach the subsequent code) and before Avalonia initialization. By forcing `AppService` initialization early, the Serilog file sink is ready before any code that might throw during startup, ensuring exceptions are logged to the application log file rather than only to the OS event log.

## 关联 issue

Closes #1300

Refs #1301 — vpk 这一半（锁版本）在本 PR 里，Velopack 库升到 1.2.0 的另一半在 anobaka/Bakabase.Infrastructures#2，合并后再单独提交主仓的 `PackageReference` + submodule 指针，届时才关掉 #1301。

**两半必须一起升**：NuGet 不跨项目统一版本，只升 `Bakabase.csproj` 会让 `Bakabase.Infrastructures` 仍编译在 0.0.1298，而输出目录只留一个 1.2.0 的 `Velopack.dll`。`AppUpdater` 的 `TargetFullRelease.Version` 正好是签名变了的成员（Velopack 1.0 把 `NuGet.Versioning` 换成了自带的 `SemanticVersion`），所以问题不会在编译期暴露，而是在第一次检查更新时抛 `MissingMethodException`。因此本 PR 只锁 vpk、不升库。

https://claude.ai/code/session_019qAoDzQkwxFC5YQPvh2SLq