### PR TITLE
Fix reference property sync to create choices and store choice IDs

### DIFF
--- a/.claude/rules/property-system.md
+++ b/.claude/rules/property-system.md
@@ -74,6 +74,14 @@ When a stored DbValue references an option that no longer exists, **every**
 read path drops the entry (and returns null when nothing is left) — no path
 leaks raw UUIDs to the UI. `DescriptorMissBehavior` tests lock this.
 
+That includes the layers above the descriptor: `Resource.Property.PropertyValue`
+carries a **null** `BizValue` rather than falling back to `Value`, so an
+uninterpretable value reads as absent instead of surfacing a bare id (for Tags
+and Multilevel such a fallback would also be the wrong shape — their biz type
+is not `ListString`). Callers treat null as "no value": the scope resolver
+skips it and moves to the next scope. `ResourcePropertyValueMissBehaviorTests`
+locks this end to end.
+
 ## PropertyValueFactory (reference types only)
 
 Only Choice/Tags/Multilevel need a factory (their db/biz values differ).

--- a/src/abstractions/Bakabase.Abstractions/Extensions/ResourceProfileExtensions.cs
+++ b/src/abstractions/Bakabase.Abstractions/Extensions/ResourceProfileExtensions.cs
@@ -64,11 +64,14 @@ public static class ResourceProfileExtensions
     /// AV sources options), but the entries themselves survived deserialization — only the
     /// removed field is silently ignored by Newtonsoft, not the whole record.
     ///
-    /// Left in place, they trip
+    /// Left in place, they used to trip
     /// <see cref="Models.Domain.EnhancerFullOptions.TargetOptions"/> handling inside
-    /// <c>ApplyEnhancementsToResources</c>'s <c>switch (targetOptions.PropertyPool)</c>
-    /// (default arm → <see cref="ArgumentOutOfRangeException"/>) and tank the Enhancement
-    /// BTask on every cycle.
+    /// <c>ApplyEnhancementsToResources</c>; that path now skips unbound entries itself,
+    /// so this strip is about keeping stored options clean rather than about crash safety.
+    ///
+    /// A <b>dynamic</b> target is exempt: its name (a regex capture group, an AI field)
+    /// is configuration in its own right, entered before any property is bound to it —
+    /// dropping it would erase what the user just typed on the way back out of the DB.
     ///
     /// Returns the number of entries dropped (for diagnostics; callers may log).
     /// </summary>
@@ -81,7 +84,8 @@ public static class ResourceProfileExtensions
             if (enhancer.TargetOptions == null) continue;
             var before = enhancer.TargetOptions.Count;
             enhancer.TargetOptions = enhancer.TargetOptions
-                .Where(t => (int)t.PropertyPool > 0 && t.PropertyId > 0)
+                .Where(t => !string.IsNullOrEmpty(t.DynamicTarget) ||
+                            ((int)t.PropertyPool > 0 && t.PropertyId > 0))
                 .ToList();
             dropped += before - enhancer.TargetOptions.Count;
         }

--- a/src/abstractions/Bakabase.Abstractions/Models/Domain/Resource.cs
+++ b/src/abstractions/Bakabase.Abstractions/Models/Domain/Resource.cs
@@ -113,8 +113,21 @@ public record Resource
         {
             public int Scope { get; set; } = Scope;
             public object? Value { get; set; } = Value;
-            public object? BizValue { get; set; } = BizValue ?? Value;
-            public object? AliasAppliedBizValue { get; set; } = AliasAppliedBizValue ?? BizValue ?? Value;
+
+            /// <summary>
+            /// Null means the descriptor could not interpret the stored db value — it points at a
+            /// choice / tag / node that no longer exists. Falling back to <see cref="Value"/> here
+            /// would leak the raw id to the UI (and, for Tags and Multilevel, a value of the wrong
+            /// shape entirely, since their biz type is not ListString), defeating the miss
+            /// behavior every read path is supposed to share. Callers treat null as absent.
+            /// </summary>
+            public object? BizValue { get; set; } = BizValue;
+
+            /// <summary>
+            /// Alias application is optional, so falling back to <see cref="BizValue"/> is correct —
+            /// falling back to <see cref="Value"/> is not, for the reason above.
+            /// </summary>
+            public object? AliasAppliedBizValue { get; set; } = AliasAppliedBizValue ?? BizValue;
 
             public bool IsManuallySet => Scope == (int)PropertyValueScope.Manual;
         }

--- a/src/legacy/Bakabase.InsideWorld.Business/Services/PathMarkSyncService.cs
+++ b/src/legacy/Bakabase.InsideWorld.Business/Services/PathMarkSyncService.cs
@@ -19,6 +19,9 @@ using Bakabase.InsideWorld.Models.Constants;
 using Bakabase.Modules.Property;
 using Bakabase.Modules.Property.Abstractions.Models.Db;
 using Bakabase.Modules.Property.Abstractions.Services;
+using Bakabase.Modules.Property.Extensions;
+using Bakabase.Modules.StandardValue;
+using Bakabase.Modules.StandardValue.Extensions;
 using Bootstrap.Components.Configuration.Abstractions;
 using CustomProperty = Bakabase.Abstractions.Models.Domain.CustomProperty;
 using Bootstrap.Components.DependencyInjection;
@@ -539,10 +542,27 @@ public class PathMarkSyncService : ScopedService
 
             if (propertyType == null) continue;
 
-            // Use PropertySystem to combine all effect values
-            var combinedValue = PropertySystem.Property.CombineSerializedDbValues(
-                propertyType.Value,
-                effects.Select(e => e.Value));
+            // A mark always yields human-readable text (a directory name, a regex capture),
+            // never an option id. For reference types (choice / tags / multilevel) that text
+            // is a biz value: combine it as one, then convert it into the db value so the
+            // option is created on the property. Skipping that step leaves the property with
+            // no options at all, so the resource filter has nothing to offer — while the
+            // resource itself still reads fine, because Resource.Property.PropertyValue
+            // falls back to the raw db value once the descriptor returns a null biz value.
+            // That fallback is what makes this failure look like a filter-only problem.
+            string? combinedValue;
+            if (pool == PropertyPool.Custom &&
+                PropertySystem.Property.IsReferenceValueType(propertyType.Value) &&
+                customProperties.TryGetValue(propertyId, out var referenceProperty))
+            {
+                combinedValue = ToReferenceDbValue(referenceProperty, effects.Select(e => e.Value), ctx);
+            }
+            else
+            {
+                combinedValue = PropertySystem.Property.CombineSerializedDbValues(
+                    propertyType.Value,
+                    effects.Select(e => e.Value));
+            }
 
             ctx.FinalPropertyValues[(resourceId, pool, propertyId)] = combinedValue;
 
@@ -583,6 +603,39 @@ public class PathMarkSyncService : ScopedService
                 }
             }
         }
+    }
+
+    /// <summary>
+    /// Combines the texts a set of marks contributed to a reference-typed property
+    /// (choice / tags / multilevel) and converts them into that property's db value,
+    /// creating an option for every label that doesn't have one yet. Properties whose
+    /// options grew are recorded on the context so Phase 3 persists them ahead of the
+    /// values pointing at them.
+    /// </summary>
+    private static string? ToReferenceDbValue(CustomProperty customProperty, IEnumerable<string?> texts,
+        SyncContext ctx)
+    {
+        var bizValueType = PropertySystem.Property.GetBizValueType(customProperty.Type);
+        var bizValues = texts
+            .Where(t => !string.IsNullOrEmpty(t))
+            .Select(t => t!.DeserializeAsStandardValue(bizValueType))
+            .ToList();
+        if (bizValues.Count == 0) return null;
+
+        // customProperty is the single instance loaded for this sync, so an option added
+        // for one resource is already on it when the next resource carrying the same
+        // label comes through — the label maps to one option id, not one per resource.
+        var property = customProperty.ToProperty();
+        var (dbValue, propertyChanged) =
+            PropertySystem.Property.ToDbValue(property, StandardValueSystem.Combine(bizValues, bizValueType));
+
+        if (propertyChanged)
+        {
+            customProperty.Options = property.Options;
+            ctx.ChangedCustomProperties[customProperty.Id] = customProperty;
+        }
+
+        return dbValue?.SerializeAsStandardValue(PropertySystem.Property.GetDbValueType(customProperty.Type));
     }
 
     /// <summary>
@@ -683,6 +736,16 @@ public class PathMarkSyncService : ScopedService
     {
         var applied = 0;
         var deleted = 0;
+
+        // Options first: a value referencing an option that isn't on the property yet
+        // reads back as empty.
+        if (ctx.ChangedCustomProperties.Count > 0)
+        {
+            await _customPropertyService.UpdateRange(
+                ctx.ChangedCustomProperties.Values.Select(p => p.ToDbModel()).ToList());
+            _logger.LogInformation("[Sync] Updated options of {Count} custom properties",
+                ctx.ChangedCustomProperties.Count);
+        }
 
         // Write property values
         if (ctx.FinalPropertyValuesToWrite.Count > 0)

--- a/src/legacy/Bakabase.InsideWorld.Business/Services/SyncContext.cs
+++ b/src/legacy/Bakabase.InsideWorld.Business/Services/SyncContext.cs
@@ -70,6 +70,11 @@ internal class SyncContext
     // Property values to write/update (already combined)
     public List<CustomPropertyValueDbModel> FinalPropertyValuesToWrite { get; } = new();
 
+    // Custom properties whose definition changed while computing values — reference
+    // types (choice / tags / multilevel) gain an option for every new label a mark
+    // extracted. They must be written before the values that point at those options.
+    public Dictionary<int, CustomProperty> ChangedCustomProperties { get; } = new();
+
     // Property values to delete (no longer have any effects)
     public List<(int ResourceId, int PropertyId)> PropertyValuesToDelete { get; } = new();
 

--- a/src/modules/Bakabase.Modules.Enhancer/Services/EnhancerService.cs
+++ b/src/modules/Bakabase.Modules.Enhancer/Services/EnhancerService.cs
@@ -135,7 +135,15 @@ namespace Bakabase.Modules.Enhancer.Services
                 {
                     continue;
                 }
-                
+
+                // A dynamic target exists as soon as it is named (a regex capture group, an
+                // AI field) — binding it to a property is a separate step the user may not
+                // have taken yet. Nothing to write until they do.
+                if ((int) targetOptions.PropertyPool <= 0 || targetOptions.PropertyId <= 0)
+                {
+                    continue;
+                }
+
                 enhancementTargetOptionsMap[enhancement] = targetOptions;
             }
 

--- a/src/tests/Bakabase.Tests/PathMarkSyncTests.cs
+++ b/src/tests/Bakabase.Tests/PathMarkSyncTests.cs
@@ -12,7 +12,11 @@ using Bakabase.Abstractions.Models.Dto;
 using Bakabase.Abstractions.Models.Input;
 using Bakabase.Abstractions.Services;
 using Bakabase.InsideWorld.Business.Services;
+using Bakabase.Modules.Property;
 using Bakabase.Modules.Property.Abstractions.Services;
+using Bakabase.Modules.Property.Components.Properties.Choice;
+using Bakabase.Modules.Property.Extensions;
+using Bakabase.Modules.StandardValue.Extensions;
 using Bakabase.TestKit.Utils;
 using Bootstrap.Components.Tasks;
 using FluentAssertions;
@@ -1763,6 +1767,102 @@ public class PathMarkSyncTests
         var bEffectsAfter = await effectService.GetPropertyEffectsByMarkIds(new[] { markB.Id });
         bEffectsAfter.Should().NotBeEmpty(
             "PATH_B's effect records must survive a sync that didn't include its mark");
+    }
+
+    #endregion
+
+    #region Reference Property Tests
+
+    /// <summary>
+    /// 属性标记提取出的是文本（目录名 / 正则捕获），不是选项 id。
+    /// 对于引用类型（多选、单选、标签、多级），同步必须把文本转成选项并写入选项 id，
+    /// 否则属性上一个选项都没有，资源筛选器里也就没有可选值。
+    ///
+    /// 注意资源详情看起来是正常的：descriptor 读到无法匹配的 db value 会返回 null，
+    /// 但 Resource.Property.PropertyValue 会回退成原始 db value，于是原始文本被当成
+    /// 标签显示了出来 —— 这也是这个 bug 看起来只影响筛选器的原因。
+    /// </summary>
+    [TestMethod]
+    public async Task PropertyMark_MultipleChoice_CreatesChoicesAndStoresChoiceIds()
+    {
+        var actionDir = Path.Combine(_testRoot, "Action", "Movie1");
+        var comedyDir = Path.Combine(_testRoot, "Comedy", "Movie2");
+        Directory.CreateDirectory(actionDir);
+        Directory.CreateDirectory(comedyDir);
+
+        var pathMarkService = _sp.GetRequiredService<IPathMarkService>();
+        var syncService = _sp.GetRequiredService<IPathMarkSyncService>();
+        var resourceService = _sp.GetRequiredService<IResourceService>();
+        var customPropertyService = _sp.GetRequiredService<ICustomPropertyService>();
+        var propertyValueService = _sp.GetRequiredService<ICustomPropertyValueService>();
+
+        var genre = await customPropertyService.Add(new CustomPropertyAddOrPutDto
+        {
+            Name = "Genre",
+            Type = PropertyType.MultipleChoice
+        });
+
+        await pathMarkService.Add(new PathMark
+        {
+            Path = _testRoot,
+            Type = PathMarkType.Resource,
+            ConfigJson = JsonConvert.SerializeObject(new ResourceMarkConfig
+            {
+                MatchMode = PathMatchMode.Layer,
+                Layer = 2,
+                FsTypeFilter = PathFilterFsType.Directory,
+                ApplyScope = PathMarkApplyScope.MatchedOnly
+            }),
+            Priority = 100
+        });
+
+        // 值取自第 1 层目录名：Action / Comedy
+        await pathMarkService.Add(new PathMark
+        {
+            Path = _testRoot,
+            Type = PathMarkType.Property,
+            ConfigJson = JsonConvert.SerializeObject(new PropertyMarkConfig
+            {
+                MatchMode = PathMatchMode.Layer,
+                Layer = 2,
+                Pool = PropertyPool.Custom,
+                PropertyId = genre.Id,
+                ValueType = PropertyValueType.Dynamic,
+                ValueLayer = 1,
+                ApplyScope = PathMarkApplyScope.MatchedOnly
+            }),
+            Priority = 50
+        });
+
+        await EnqueueAndWaitSync(syncService);
+
+        var refreshed = await customPropertyService.GetByKey(genre.Id);
+        var options = refreshed.Options as MultipleChoicePropertyOptions;
+        options.Should().NotBeNull("extracted labels must become choices on the property");
+        var choiceMap = options!.Choices!.ToDictionary(c => c.Label, c => c.Value);
+        choiceMap.Keys.Should().BeEquivalentTo(new[] {"Action", "Comedy"});
+
+        var resources = await resourceService.GetAll();
+        var expectations = new Dictionary<string, string>
+        {
+            [actionDir] = "Action",
+            [comedyDir] = "Comedy"
+        };
+
+        foreach (var (path, label) in expectations)
+        {
+            var resource = resources.Should().ContainSingle(r => r.Path == path).Subject;
+            var values = await propertyValueService.GetAllDbModels(v =>
+                v.ResourceId == resource.Id && v.PropertyId == genre.Id);
+            var value = values.Should().ContainSingle().Subject;
+
+            var dbValue = value.Value.DeserializeAsStandardValue<List<string>>(StandardValueType.ListString);
+            dbValue.Should().BeEquivalentTo(new[] {choiceMap[label]},
+                "the stored value must be the choice id, not the raw label");
+
+            var bizValue = PropertySystem.Property.ToBizValue(refreshed.ToProperty(), dbValue);
+            bizValue.Should().BeEquivalentTo(new[] {label}, "the value must read back as its label");
+        }
     }
 
     #endregion

--- a/src/tests/Bakabase.Tests/ResourceProfileEnhancerOptionsTests.cs
+++ b/src/tests/Bakabase.Tests/ResourceProfileEnhancerOptionsTests.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Linq;
 using Bakabase.Abstractions.Extensions;
 using Bakabase.Abstractions.Models.Db;
 using Bakabase.Abstractions.Models.Domain;
@@ -50,6 +51,46 @@ public class ResourceProfileEnhancerOptionsTests
         dropped.Should().Be(3);
         options.Enhancers![0].TargetOptions.Should().HaveCount(1);
         options.Enhancers[0].TargetOptions![0].Target.Should().Be(1);
+    }
+
+    /// <summary>
+    /// A dynamic target's name (a regex capture group, an AI field) is configuration in
+    /// its own right and is entered before any property is bound to it — the binding is
+    /// made afterwards, in the panel that lists those names. Stripping it on read would
+    /// erase what the user just configured.
+    /// </summary>
+    [TestMethod]
+    public void StripInvalidEnhancerTargetOptions_KeepsUnboundDynamicTargets()
+    {
+        var options = new ResourceProfileEnhancerOptions
+        {
+            Enhancers = new List<EnhancerFullOptions>
+            {
+                new()
+                {
+                    EnhancerId = 4,
+                    TargetOptions = new List<EnhancerTargetFullOptions>
+                    {
+                        // A capture group the user named but hasn't bound yet — keep.
+                        new() { Target = 0, DynamicTarget = "author" },
+                        // Bound capture group — keep.
+                        new()
+                        {
+                            Target = 0, DynamicTarget = "series",
+                            PropertyPool = PropertyPool.Custom, PropertyId = 42
+                        },
+                        // Unnamed and unbound — nothing to keep.
+                        new() { Target = 0 },
+                    },
+                },
+            },
+        };
+
+        var dropped = options.StripInvalidEnhancerTargetOptions();
+
+        dropped.Should().Be(1);
+        options.Enhancers![0].TargetOptions!.Select(t => t.DynamicTarget)
+            .Should().BeEquivalentTo(new[] {"author", "series"});
     }
 
     [TestMethod]

--- a/src/tests/Bakabase.Tests/ResourcePropertyValueMissBehaviorTests.cs
+++ b/src/tests/Bakabase.Tests/ResourcePropertyValueMissBehaviorTests.cs
@@ -1,0 +1,97 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Bakabase.Abstractions.Models.Domain;
+using Bakabase.Abstractions.Models.Domain.Constants;
+using Bakabase.Abstractions.Models.Dto;
+using Bakabase.Abstractions.Services;
+using Bakabase.InsideWorld.Models.Constants.AdditionalItems;
+using Bakabase.Modules.Property.Abstractions.Models.Db;
+using Bakabase.Modules.Property.Abstractions.Services;
+using Bakabase.Modules.Property.Components.Properties.Choice;
+using Bakabase.TestKit.Utils;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json;
+
+namespace Bakabase.Tests;
+
+/// <summary>
+/// A stored db value that matches no option must read back as absent on EVERY path, not just
+/// inside the descriptor. <see cref="Resource.Property.PropertyValue"/> used to fall back to
+/// the raw db value whenever the biz value came back null, which put bare choice ids (and,
+/// for Tags / Multilevel, values of the wrong shape) straight into the UI.
+/// </summary>
+[TestClass]
+public class ResourcePropertyValueMissBehaviorTests
+{
+    [TestMethod]
+    public void PropertyValue_NullBizValue_DoesNotFallBackToDbValue()
+    {
+        var value = new Resource.Property.PropertyValue(
+            (int) PropertyValueScope.Synchronization, new List<string> {"uuid-deleted"}, null, null);
+
+        value.Value.Should().BeEquivalentTo(new[] {"uuid-deleted"});
+        value.BizValue.Should().BeNull();
+        value.AliasAppliedBizValue.Should().BeNull();
+    }
+
+    [TestMethod]
+    public void PropertyValue_AliasAppliedStillFallsBackToBizValue()
+    {
+        // Alias application is optional, so this fallback is the one that must stay.
+        var value = new Resource.Property.PropertyValue(
+            (int) PropertyValueScope.Synchronization, new List<string> {"uuid-a"},
+            new List<string> {"A"}, null);
+
+        value.AliasAppliedBizValue.Should().BeEquivalentTo(new[] {"A"});
+    }
+
+    /// <summary>
+    /// End to end: a MultipleChoice value pointing at a choice the property no longer has must
+    /// come back from the resource read with no biz value at all.
+    /// </summary>
+    [TestMethod]
+    public async Task ResourceRead_DeletedChoice_YieldsNoBizValue()
+    {
+        var sp = await TestServiceBuilder.BuildServiceProvider();
+        var customPropertyService = sp.GetRequiredService<ICustomPropertyService>();
+        var propertyValueService = sp.GetRequiredService<ICustomPropertyValueService>();
+        var resourceService = sp.GetRequiredService<IResourceService>();
+
+        var genre = await customPropertyService.Add(new CustomPropertyAddOrPutDto
+        {
+            Name = "Genre",
+            Type = PropertyType.MultipleChoice,
+            Options = JsonConvert.SerializeObject(new MultipleChoicePropertyOptions
+            {
+                Choices = [new() {Label = "Action", Value = "uuid-action"}]
+            })
+        });
+
+        await resourceService.AddOrPutRange([
+            new Resource {Path = Path.Combine(Path.GetTempPath(), "miss-behavior-probe"), IsFile = false}
+        ]);
+        var resourceId = (await resourceService.GetAll()).Single().Id;
+
+        await propertyValueService.AddDbModelRange([
+            new CustomPropertyValueDbModel
+            {
+                ResourceId = resourceId,
+                PropertyId = genre.Id,
+                // Serialized ListString holding a single id the property no longer carries.
+                Value = "uuid-deleted",
+                Scope = (int) PropertyValueScope.Synchronization
+            }
+        ]);
+
+        var reloaded = await resourceService.Get(resourceId, ResourceAdditionalItem.Properties);
+        var value = reloaded!.Properties![(int) PropertyPool.Custom][genre.Id].Values!.Single();
+
+        value.Value.Should().BeEquivalentTo(new[] {"uuid-deleted"}, "the db value is kept as stored");
+        value.BizValue.Should().BeNull("a db value matching no choice must not reach the UI");
+        value.AliasAppliedBizValue.Should().BeNull();
+    }
+}

--- a/src/web/src/components/EnhancerSelectorV2/components/EnhancerOptionsModal/components/DynamicTargets.tsx
+++ b/src/web/src/components/EnhancerSelectorV2/components/EnhancerOptionsModal/components/DynamicTargets.tsx
@@ -78,6 +78,11 @@ const DynamicTargets = (props: Props) => {
   const dynamicTargetDescriptors = enhancer.targets.filter((x) => x.isDynamic);
   const [groups, setGroups] = useState<Group[]>([]);
 
+  // The host rebuilds candidateTargetsMap on every render, so key the effect off its
+  // contents instead of its identity — otherwise this re-runs (and resets the rows)
+  // on renders that changed nothing about the targets.
+  const candidateTargetsKey = JSON.stringify(candidateTargetsMap);
+
   useEffect(() => {
     const newGroups = buildGroups(dynamicTargetDescriptors, optionsList, candidateTargetsMap);
 
@@ -130,7 +135,7 @@ const DynamicTargets = (props: Props) => {
 
       onChange?.(ol);
     }
-  }, [candidateTargetsMap]);
+  }, [candidateTargetsKey, optionsList]);
 
   const updateGroups = (groups: Group[]) => {
     setGroups([...groups]);

--- a/src/web/src/components/EnhancerSelectorV2/components/EnhancerOptionsModal/components/TargetRow/index.tsx
+++ b/src/web/src/components/EnhancerSelectorV2/components/EnhancerOptionsModal/components/TargetRow/index.tsx
@@ -98,10 +98,15 @@ const TargetRow = (props: Props) => {
     setOptions(newOptions);
     log("Patch target options", newOptions);
 
-    if (
-      !newOptions.autoBindProperty &&
-      (newOptions.propertyPool == undefined || newOptions.propertyId == undefined)
-    ) {
+    // A dynamic row counts as configured the moment it is named — the name is the
+    // configuration (a regex capture group), and binding it to a property is a
+    // separate step that may happen here or in the panel that opened this modal.
+    const isConfigured =
+      newOptions.autoBindProperty ||
+      (newOptions.propertyPool != undefined && newOptions.propertyId != undefined) ||
+      (descriptor.isDynamic && newOptions.dynamicTarget != undefined);
+
+    if (!isConfigured) {
       return;
     }
 
@@ -226,7 +231,13 @@ const TargetRow = (props: Props) => {
               type={descriptor.propertyType}
               onValueChanged={(property) => {
                 if (!property) {
-                  onDeleted?.();
+                  // A candidate-driven row can't be removed — its name comes from the
+                  // configuration above — so clearing it means "unbind", not "delete".
+                  if (onDeleted) {
+                    onDeleted();
+                  } else {
+                    patchTargetOptions({ propertyId: undefined, propertyPool: undefined });
+                  }
 
                   return;
                 }

--- a/src/web/src/components/EnhancerSelectorV2/components/EnhancerOptionsModal/index.tsx
+++ b/src/web/src/components/EnhancerSelectorV2/components/EnhancerOptionsModal/index.tsx
@@ -1,7 +1,10 @@
 "use client";
 
 import type { EnhancerDescriptor } from "@/components/EnhancerSelectorV2/models";
-import type { EnhancerFullOptions } from "@/components/EnhancerSelectorV2/models";
+import type {
+  EnhancerFullOptions,
+  EnhancerTargetFullOptions,
+} from "@/components/EnhancerSelectorV2/models";
 import type { IProperty } from "@/components/Property/models";
 import type { DestroyableProps } from "@/components/bakaui/types";
 import type { BangumiSubjectType } from "@/sdk/constants";
@@ -306,7 +309,7 @@ export default function EnhancerOptionsModal({
   const expressions = options?.expressions || [];
   const captureGroups = extractCaptureGroups(expressions);
   const prerequisiteEnhancers = options.requirements?.map((r) => r.toString());
-  let candidateTargetsMap: Record<number, string[] | undefined> = {};
+  const candidateTargetsMap: Record<number, string[] | undefined> = {};
 
   if (enhancer.id == EnhancerId.Regex) {
     candidateTargetsMap[RegexEnhancerTarget.CaptureGroups] = captureGroups;
@@ -314,55 +317,27 @@ export default function EnhancerOptionsModal({
 
   const hasDynamicTargets = enhancer.targets?.some((t) => t.isDynamic);
   const hasFixedTargets = enhancer.targets?.some((t) => !t.isDynamic);
-  // When candidateTargetsMap is populated (e.g. Regex), dynamic targets are fully driven by candidates
-  const hasCandidateTargets = Object.keys(candidateTargetsMap).length > 0;
 
-  // Auto-sync candidate targets (e.g. regex capture groups) into targetOptions
-  // so that DynamicTargets UI is not needed for candidate-driven enhancers
-  const captureGroupsKey = captureGroups.join("\0");
+  const dynamicTargetIds = new Set(
+    (enhancer.targets ?? []).filter((t) => t.isDynamic).map((t) => t.id),
+  );
+  /** A row belongs to the dynamic table once it names one of this enhancer's dynamic targets. */
+  const isDynamicRow = (to: EnhancerTargetFullOptions) =>
+    dynamicTargetIds.has(to.target) && to.dynamicTarget != undefined;
 
-  useEffect(() => {
-    if (!hasCandidateTargets) return;
-
-    const dynamicDescriptor = enhancer.targets.find((t) => t.isDynamic);
-
-    if (!dynamicDescriptor) return;
-
-    setOptions((prev) => {
-      const current = prev.targetOptions ?? [];
-
-      // Separate non-candidate targets from candidate-driven ones
-      const kept = current.filter(
-        (to) => to.target !== dynamicDescriptor.id || to.dynamicTarget == undefined,
-      );
-
-      // Build synced list from candidates, preserving existing config (property binding etc.)
-      const existingByName = new Map(
-        current
-          .filter((to) => to.target === dynamicDescriptor.id && to.dynamicTarget != undefined)
-          .map((to) => [to.dynamicTarget!, to]),
-      );
-
-      const synced = captureGroups.map(
-        (group) =>
-          existingByName.get(group) ?? { target: dynamicDescriptor.id, dynamicTarget: group },
-      );
-
-      // Check if anything actually changed
-      const oldDynamic = current.filter(
-        (to) => to.target === dynamicDescriptor.id && to.dynamicTarget != undefined,
-      );
-
-      if (
-        synced.length === oldDynamic.length &&
-        synced.every((s, i) => s.dynamicTarget === oldDynamic[i]?.dynamicTarget)
-      ) {
-        return prev;
-      }
-
-      return { ...prev, targetOptions: [...kept, ...synced] };
-    });
-  }, [captureGroupsKey]);
+  /**
+   * Each table owns one slice of targetOptions and reports only that slice, so merge
+   * rather than replace — otherwise editing one table drops the other table's rows.
+   */
+  const mergeTargetOptions = (list: EnhancerTargetFullOptions[], fromDynamicTable: boolean) => {
+    setOptions((prev) => ({
+      ...prev,
+      targetOptions: [
+        ...(prev.targetOptions ?? []).filter((to) => isDynamicRow(to) !== fromDynamicTable),
+        ...list.filter((to) => isDynamicRow(to) === fromDynamicTable),
+      ],
+    }));
+  };
 
   return (
     <Modal
@@ -379,11 +354,15 @@ export default function EnhancerOptionsModal({
       }
       onDestroyed={onDestroyed}
       onOk={async () => {
-        // Filter out target entries without valid property binding to prevent saving invalid data
+        // Drop fixed targets that were never bound — they carry nothing but a target id.
+        // A named dynamic target is kept even when unbound: its name is the configuration
+        // (a regex capture group), and in `hideBindingAndConfig` mode the binding is made
+        // by the panel that opened this modal, after it reads these entries back.
         const sanitized = {
           ...options,
           targetOptions: options.targetOptions?.filter(
             (to) =>
+              to.dynamicTarget != undefined ||
               to.autoBindProperty ||
               (to.propertyPool && to.propertyPool > 0 && to.propertyId && to.propertyId > 0),
           ),
@@ -484,7 +463,7 @@ export default function EnhancerOptionsModal({
         />
       </div>
 
-      {(hasFixedTargets || (hasDynamicTargets && !hasCandidateTargets)) && (
+      {(hasFixedTargets || hasDynamicTargets) && (
         <div>
           <div className="text-base">
             {t<string>("enhancer.options.enhanceProperties.label")}
@@ -500,28 +479,18 @@ export default function EnhancerOptionsModal({
                   hideBindingAndConfig={hideBindingAndConfig}
                   optionsList={options.targetOptions}
                   propertyMap={propertyMap}
-                  onChange={(list) => {
-                    setOptions({
-                      ...options,
-                      targetOptions: list,
-                    });
-                  }}
+                  onChange={(list) => mergeTargetOptions(list, false)}
                   onPropertyChanged={loadAllProperties}
                 />
               )}
-              {hasDynamicTargets && !hasCandidateTargets && (
+              {hasDynamicTargets && (
                 <DynamicTargets
                   candidateTargetsMap={candidateTargetsMap}
                   enhancer={enhancer}
                   hideBindingAndConfig={hideBindingAndConfig}
                   optionsList={options.targetOptions}
                   propertyMap={propertyMap}
-                  onChange={(list) => {
-                    setOptions({
-                      ...options,
-                      targetOptions: list,
-                    });
-                  }}
+                  onChange={(list) => mergeTargetOptions(list, true)}
                   onPropertyChanged={loadAllProperties}
                 />
               )}

--- a/src/web/src/components/Resource/components/DetailModal/Properties/PropertyContainer/ScopePreferencePopover.tsx
+++ b/src/web/src/components/Resource/components/DetailModal/Properties/PropertyContainer/ScopePreferencePopover.tsx
@@ -31,8 +31,18 @@ type Props = {
   onOpenChange?: (open: boolean) => void;
 };
 
-const hasValue = (v?: { value?: any; bizValue?: any }) => {
-  const x = v?.bizValue ?? v?.value;
+/**
+ * The scope resolver decides emptiness from `aliasAppliedBizValue ?? bizValue`
+ * (PropertyValueScopeResolver.IsNonEmptyValue) — read the same pair here. Falling back to
+ * the raw db value would call a scope non-empty that the resolver skips, and preview it as
+ * a bare choice id.
+ */
+type ScopeValue = { bizValue?: any; aliasAppliedBizValue?: any };
+
+const effectiveValueOf = (v?: ScopeValue) => v?.aliasAppliedBizValue ?? v?.bizValue;
+
+const hasValue = (v?: ScopeValue) => {
+  const x = effectiveValueOf(v);
 
   if (x == null) return false;
   if (Array.isArray(x)) return x.length > 0;
@@ -41,8 +51,8 @@ const hasValue = (v?: { value?: any; bizValue?: any }) => {
   return true;
 };
 
-const previewText = (v?: { value?: any; bizValue?: any }) => {
-  const x = v?.bizValue ?? v?.value;
+const previewText = (v?: ScopeValue) => {
+  const x = effectiveValueOf(v);
 
   if (x == null) return "";
   if (Array.isArray(x))

--- a/src/web/src/pages/resource/components/SearchSummary/__tests__/index.test.tsx
+++ b/src/web/src/pages/resource/components/SearchSummary/__tests__/index.test.tsx
@@ -141,6 +141,29 @@ describe("SearchSummary", () => {
     expect(host.querySelector(".text-primary")).toBeNull();
   });
 
+  // A filter with a property and an operator but no value is dropped server-side,
+  // so listing it here described a criterion that never ran — "Author contains",
+  // with nothing after it.
+  it("leaves out a filter the user never gave a value to", () => {
+    const host = render(
+      <SearchSummary
+        form={form({
+          group: group({ filters: [filter("Author"), filter("Series", "bleach")] }),
+        })}
+      />,
+    );
+
+    expect(host.textContent).not.toContain("Author");
+    expect(host.textContent).toContain("Series");
+  });
+
+  it("says a tab carries no criteria when none of its filters has a value", () => {
+    expect(
+      render(<SearchSummary form={form({ group: group({ filters: [filter("Author")] }) })} />)
+        .textContent,
+    ).toBe("resource.tab.summary.empty");
+  });
+
   it("keeps a disabled filter visible but struck through", () => {
     const host = render(
       <SearchSummary

--- a/src/web/src/pages/resource/components/SearchSummary/index.tsx
+++ b/src/web/src/pages/resource/components/SearchSummary/index.tsx
@@ -10,7 +10,11 @@ import { MdOutlineFilterAltOff } from "react-icons/md";
 import { GroupCombinator } from "@/components/ResourceFilter/models";
 import { getOperationDisplay } from "@/components/ResourceFilter/components/Filter/utils";
 import { filterValueToText } from "@/pages/resource/utils/filterValueToText";
-import { groupHasContent, hasSearchSummary } from "@/pages/resource/utils/searchSummary";
+import {
+  effectiveFiltersOf,
+  groupHasContent,
+  hasSearchSummary,
+} from "@/pages/resource/utils/searchSummary";
 import { getEnumKey } from "@/i18n";
 import { resourceSearchSortableProperties, resourceTags, SearchOperation } from "@/sdk/constants";
 
@@ -30,9 +34,13 @@ type GroupChild =
   | { kind: "filter"; filter: SearchFilter }
   | { kind: "group"; group: SearchFilterGroup };
 
-/** A group's rows, in the order they read: own filters first, then subgroups. */
+/**
+ * A group's rows, in the order they read: own filters first, then subgroups.
+ * A filter the user never gave a value to is left out — it doesn't narrow the
+ * search, so naming it here would only describe a criterion that never ran.
+ */
 const childrenOf = (group: SearchFilterGroup): GroupChild[] => [
-  ...(group.filters ?? []).map((filter) => ({ kind: "filter" as const, filter })),
+  ...effectiveFiltersOf(group).map((filter) => ({ kind: "filter" as const, filter })),
   ...(group.groups ?? [])
     .filter(groupHasContent)
     .map((child) => ({ kind: "group" as const, group: child })),

--- a/src/web/src/pages/resource/utils/__tests__/searchSummary.test.ts
+++ b/src/web/src/pages/resource/utils/__tests__/searchSummary.test.ts
@@ -4,7 +4,12 @@ import type { SearchForm } from "@/pages/resource/models";
 import { describe, expect, it } from "vitest";
 
 import { buildAutoTabName } from "../buildAutoTabName";
-import { groupHasContent, hasSearchSummary } from "../searchSummary";
+import {
+  effectiveFiltersOf,
+  filterIsEffective,
+  groupHasContent,
+  hasSearchSummary,
+} from "../searchSummary";
 
 import { GroupCombinator } from "@/components/ResourceFilter/models";
 import { PropertyPool, PropertyType, ResourceTag, SearchOperation } from "@/sdk/constants";
@@ -14,6 +19,7 @@ const filter = (bizValue?: string, disabled = false): SearchFilter => ({
   propertyPool: PropertyPool.Custom,
   operation: SearchOperation.Contains,
   bizValue,
+  dbValue: bizValue,
   disabled,
   property: {
     id: 1,
@@ -21,6 +27,12 @@ const filter = (bizValue?: string, disabled = false): SearchFilter => ({
     name: "Name",
     type: PropertyType.SingleLineText,
   } as SearchFilter["property"],
+});
+
+/** A filter the user picked a property for but never gave a value to. */
+const valuelessFilter = (operation: SearchOperation = SearchOperation.Contains): SearchFilter => ({
+  ...filter(),
+  operation,
 });
 
 const group = (partial: Partial<SearchFilterGroup> = {}): SearchFilterGroup => ({
@@ -35,10 +47,49 @@ const form = (partial: Partial<SearchForm> = {}): SearchForm => ({
   ...partial,
 });
 
+describe("filterIsEffective", () => {
+  it("is true for a filter carrying a value", () => {
+    expect(filterIsEffective(filter("a"))).toBe(true);
+  });
+
+  it("is false for a filter the user never gave a value to", () => {
+    expect(filterIsEffective(valuelessFilter())).toBe(false);
+    expect(filterIsEffective(valuelessFilter(SearchOperation.In))).toBe(false);
+    expect(filterIsEffective({ ...filter(), bizValue: "", dbValue: "" })).toBe(false);
+  });
+
+  it("is true for the operations that carry no value by design", () => {
+    expect(filterIsEffective(valuelessFilter(SearchOperation.IsNull))).toBe(true);
+    expect(filterIsEffective(valuelessFilter(SearchOperation.IsNotNull))).toBe(true);
+  });
+
+  it("is false without a property or an operation", () => {
+    expect(filterIsEffective({ ...filter("a"), propertyId: undefined })).toBe(false);
+    expect(filterIsEffective({ ...filter("a"), propertyPool: undefined })).toBe(false);
+    expect(filterIsEffective({ ...filter("a"), operation: undefined })).toBe(false);
+  });
+});
+
+describe("effectiveFiltersOf", () => {
+  it("keeps only the filters that narrow the search, in order", () => {
+    const a = filter("a");
+    const b = filter("b");
+
+    expect(effectiveFiltersOf(group({ filters: [a, valuelessFilter(), b] }))).toEqual([a, b]);
+  });
+});
+
 describe("groupHasContent", () => {
   it("is false for an empty group", () => {
     expect(groupHasContent(group())).toBe(false);
     expect(groupHasContent(group({ filters: [], groups: [] }))).toBe(false);
+  });
+
+  it("is false for a group holding only valueless filters", () => {
+    expect(groupHasContent(group({ filters: [valuelessFilter()] }))).toBe(false);
+    expect(groupHasContent(group({ groups: [group({ filters: [valuelessFilter()] })] }))).toBe(
+      false,
+    );
   });
 
   it("is true for a group holding a filter", () => {
@@ -73,6 +124,10 @@ describe("hasSearchSummary", () => {
 
   it("ignores empty collections", () => {
     expect(hasSearchSummary(form({ keyword: "", tags: [], orders: [] }))).toBe(false);
+  });
+
+  it("is false when the only filter has no value", () => {
+    expect(hasSearchSummary(form({ group: group({ filters: [valuelessFilter()] }) }))).toBe(false);
   });
 });
 

--- a/src/web/src/pages/resource/utils/searchSummary.ts
+++ b/src/web/src/pages/resource/utils/searchSummary.ts
@@ -1,9 +1,37 @@
-import type { SearchFilterGroup } from "@/components/ResourceFilter/models";
+import type { SearchFilter, SearchFilterGroup } from "@/components/ResourceFilter/models";
 import type { SearchForm } from "@/pages/resource/models";
 
-/** True when the group, or any group nested under it, holds a filter. */
+import { SearchOperation } from "@/sdk/constants";
+
+/**
+ * True when a filter actually narrows the search.
+ *
+ * A filter the user picked a property for but never gave a value to is dropped
+ * server-side (`ResourceSearchExtensions.IsValid`), so summarizing it would
+ * describe a criterion that never ran — "Genre in", with nothing after it.
+ * `IsNull` / `IsNotNull` are the two operations that carry no value by design.
+ */
+export const filterIsEffective = (filter: SearchFilter): boolean => {
+  if (filter.propertyId == undefined || filter.propertyPool == undefined) return false;
+  if (filter.operation == undefined) return false;
+
+  if (
+    filter.operation === SearchOperation.IsNull ||
+    filter.operation === SearchOperation.IsNotNull
+  ) {
+    return true;
+  }
+
+  return !!filter.dbValue || !!filter.bizValue;
+};
+
+/** The filters of a group that are worth summarizing, in their original order. */
+export const effectiveFiltersOf = (group: SearchFilterGroup): SearchFilter[] =>
+  (group.filters ?? []).filter(filterIsEffective);
+
+/** True when the group, or any group nested under it, holds an effective filter. */
 export const groupHasContent = (group: SearchFilterGroup): boolean =>
-  (group.filters?.length ?? 0) > 0 || (group.groups ?? []).some(groupHasContent);
+  effectiveFiltersOf(group).length > 0 || (group.groups ?? []).some(groupHasContent);
 
 /** True when the form carries anything worth summarizing in the tab tooltip. */
 export const hasSearchSummary = (form: SearchForm | undefined): boolean => {


### PR DESCRIPTION
## Summary

Fixes a bug where path mark synchronization of reference-type properties (MultipleChoice, SingleChoice, Tags, Multilevel) extracted text values but failed to convert them to choice IDs before storage. This left properties with no options and made them appear empty in resource filters, even though the raw text was readable in resource details (due to a fallback in `Resource.Property.PropertyValue`).

## Key Changes

### Backend (C#)

- **PathMarkSyncService**: Added `ToReferenceDbValue()` method to convert extracted text labels into choice IDs for reference-type properties, creating missing options on-the-fly. Options are persisted before values that reference them.
- **SyncContext**: Added `ChangedCustomProperties` dictionary to track properties whose options grew during sync.
- **Resource.PropertyValue**: Removed fallback from `BizValue` to `Value` (and from `AliasAppliedBizValue` to `Value`). When a stored ID references a deleted choice, `BizValue` now correctly returns null instead of leaking the raw ID to the UI. Alias application still falls back to `BizValue` as intended.
- **ResourceProfileExtensions**: Updated documentation to clarify that dynamic targets (regex capture groups, AI fields) are exempt from stripping — their names are configuration in their own right.
- **EnhancerService**: Added check to skip writing dynamic targets that have been named but not yet bound to a property.

### Frontend (TypeScript/React)

- **EnhancerOptionsModal**: Refactored target option handling to use `mergeTargetOptions()` instead of replacing the entire list, so editing one table (fixed vs. dynamic) no longer drops the other table's rows. Removed the `useEffect` that auto-synced candidate targets; dynamic targets are now always shown.
- **TargetRow**: A dynamic target is now considered "configured" as soon as it is named (before any property binding). Clearing a property binding on a candidate-driven row now unbinds rather than deletes.
- **DynamicTargets**: Added key-off-contents pattern to prevent re-running the effect on renders that didn't change the targets.
- **SearchSummary & searchSummary utils**: Added `filterIsEffective()` and `effectiveFiltersOf()` to exclude valueless filters (those with a property and operator but no value) from summaries, since they are dropped server-side and never actually run.
- **ScopePreferencePopover**: Updated to read `aliasAppliedBizValue ?? bizValue` (matching the scope resolver) instead of falling back to raw `value`, preventing bare choice IDs from appearing in the UI.

### Tests

- **PathMarkSyncTests**: Added `PropertyMark_MultipleChoice_CreatesChoicesAndStoresChoiceIds()` to verify that extracted labels become choices and are stored as choice IDs.
- **ResourcePropertyValueMissBehaviorTests**: New test class verifying that `Resource.Property.PropertyValue` does not fall back to raw db values when `BizValue` is null.
- **ResourceProfileEnhancerOptionsTests**: Added `StripInvalidEnhancerTargetOptions_KeepsUnboundDynamicTargets()` to verify that named but unbound dynamic targets are preserved.
- **SearchSummary tests**: Added tests for `filterIsEffective()` and `effectiveFiltersOf()`, and verified that valueless filters are excluded from summaries.

## Notable Implementation Details

- The fix ensures that **every read path** (descriptor, `PropertyValue`, UI) treats a deleted choice the same way: as absent. This prevents the raw ID from leaking to the UI while keeping the stored value intact for potential future recovery.
- Dynamic targets (regex capture groups, AI fields) are now treated as configuration in their own right — they exist as soon as they are named, and property binding is a separate optional step.
- The sync process now creates missing options on the property before writing values that reference them, ensuring referential integrity.

https://claude.ai/code/session_012xHBBXMwh29AfjJKc27XKu