### PR TITLE
Improve app shutdown responsiveness and task cancellation

### DIFF
--- a/.claude/rules/btask.md
+++ b/.claude/rules/btask.md
@@ -414,22 +414,35 @@ Updates are batched every 500ms to reduce UI thrashing.
 
 ## App Shutdown
 
-Two steps, and the order matters:
+`ExitCoordinator` (desktop app) drives it, in this order — the order is the point:
 
-| Step | Who calls it | What it does |
-|------|--------------|--------------|
-| `PrepareForShutdown()` | `ExitCoordinator`, as soon as the user commits to quitting | Stops the daemon promoting new tasks, then asks every **non-Critical** active task to stop |
-| `DisposeAsync()` | Container teardown, i.e. after the web host has stopped | Cancels the daemon, runs `PrepareForShutdown()` again (idempotent), then waits for **Critical** tasks |
+1. **`BTaskManager.PrepareForShutdown()`** — the moment the user commits to
+   quitting. Stops the daemon promoting new tasks, then asks every
+   **non-Critical** active task to stop. Critical tasks are deliberately not
+   asked: interrupting them is what loses data.
+2. **Wait for everything to go quiet** — cancelled tasks get a bounded grace
+   (`CancelledTaskDrainTimeout`, 10s) to reach their next checkpoint and release
+   their DB and file handles; Critical tasks are waited for without a bound,
+   with "Quit now" offered to the user after 6s.
+3. **`host.StopAsync()` + container disposal** — only now, because this is what
+   tears down the services a task body is still holding between checkpoints.
+   `DisposeAsync` re-runs `PrepareForShutdown()` (idempotent) and waits for
+   Critical tasks again, so a headless host still winds down correctly on its own.
 
-`PrepareForShutdown` exists because disposal happens far too late to be the
-first time anything asks a task to stop: the host stop in between can take
-many seconds, during which the exit window would show tasks still working and
-still ticking up. Critical tasks are deliberately left alone — the exit flow
-waits for those, and offers the user "Quit now" if the wait drags on.
+Both waits are bounded from the app's side, but a task only stops as fast as
+its body cooperates — see the yield-point rules above, and keep long
+synchronous stretches (recursive directory walks especially) cancellable, or
+step 2 just burns its grace period and gives up.
 
-A task only stops as fast as its body cooperates, so this is only half the
-story — see the yield-point rules above, and keep long synchronous stretches
-(recursive directory walks especially) cancellable.
+### Levels in practice
+
+`BTaskLevel.Critical` currently has **no members** — every task in the app is
+`Default`, i.e. stoppable. That is a deliberate reading of each task, not an
+oversight: the index/cache tasks rebuild from scratch next launch, the sync and
+download tasks resume, `ResourceMove` marks itself interrupted on startup, and
+`MoveFiles` checks cancellation between independent file sets. Before marking
+anything Critical, be sure interruption genuinely loses data — the level makes
+exit wait on it indefinitely.
 
 ## Known Limitations
 

--- a/.claude/rules/btask.md
+++ b/.claude/rules/btask.md
@@ -412,6 +412,25 @@ Tasks are pushed to the frontend via SignalR:
 
 Updates are batched every 500ms to reduce UI thrashing.
 
+## App Shutdown
+
+Two steps, and the order matters:
+
+| Step | Who calls it | What it does |
+|------|--------------|--------------|
+| `PrepareForShutdown()` | `ExitCoordinator`, as soon as the user commits to quitting | Stops the daemon promoting new tasks, then asks every **non-Critical** active task to stop |
+| `DisposeAsync()` | Container teardown, i.e. after the web host has stopped | Cancels the daemon, runs `PrepareForShutdown()` again (idempotent), then waits for **Critical** tasks |
+
+`PrepareForShutdown` exists because disposal happens far too late to be the
+first time anything asks a task to stop: the host stop in between can take
+many seconds, during which the exit window would show tasks still working and
+still ticking up. Critical tasks are deliberately left alone — the exit flow
+waits for those, and offers the user "Quit now" if the wait drags on.
+
+A task only stops as fast as its body cooperates, so this is only half the
+story — see the yield-point rules above, and keep long synchronous stretches
+(recursive directory walks especially) cancellable.
+
 ## Known Limitations
 
 1. **No priority queue** - All eligible tasks compete equally

--- a/src/abstractions/Bakabase.Abstractions/Components/Tasks/BTaskManager.cs
+++ b/src/abstractions/Bakabase.Abstractions/Components/Tasks/BTaskManager.cs
@@ -270,12 +270,24 @@ public class BTaskManager : IAsyncDisposable
         return (blockers.ToArray(), shouldFail);
     }
 
+    /// <summary>
+    /// Set once the app has committed to quitting. Keeps the daemon from promoting a task while
+    /// everything else is being wound down — a recurring task started at that moment would come
+    /// up against a container that is about to be disposed.
+    /// </summary>
+    private volatile bool _shuttingDown;
+
     private Task Daemon()
     {
         _daemonTask = Task.Run(async () =>
         {
             while (!_daemonCts.IsCancellationRequested)
             {
+                if (_shuttingDown)
+                {
+                    break;
+                }
+
                 try
                 {
                     var now = DateTime.Now;
@@ -404,6 +416,41 @@ public class BTaskManager : IAsyncDisposable
     public BTaskViewModel? GetTaskViewModel(string id) =>
         _taskMap.TryGetValue(id, out var bt) ? BuildTaskViewModel(bt) : null;
 
+    /// <summary>
+    /// Asks every non-Critical task to stop, and stops the daemon from starting new ones.
+    ///
+    /// Split out of <see cref="DisposeAsync"/> so a shutdown can ask the moment the user commits
+    /// to quitting. Disposal only runs once the host has stopped, which can take many seconds —
+    /// and until this call existed nothing had asked the running tasks to wind down, so they kept
+    /// working (and kept ticking up in the exit window) for that whole wait.
+    ///
+    /// Idempotent, and safe to call before <see cref="DisposeAsync"/>: stopping an
+    /// already-cancelled task is a no-op.
+    /// </summary>
+    public async Task PrepareForShutdown()
+    {
+        _shuttingDown = true;
+
+        var nonCriticalTasks = _taskMap.Values
+            .Where(t => t.Task.Level != BTaskLevel.Critical && t.Task.Status.IsActive())
+            .ToList();
+
+        foreach (var task in nonCriticalTasks)
+        {
+            _logger.LogInformation($"Stopping non-critical task: {task.Id}");
+            try
+            {
+                await task.Stop();
+            }
+            catch (Exception e)
+            {
+                // One uncooperative task must not stop us asking the rest; disposal cancels it
+                // regardless.
+                _logger.LogWarning(e, $"Failed to stop task [{task.Id}] while shutting down");
+            }
+        }
+    }
+
     public async ValueTask DisposeAsync()
     {
         _optionsChangeHandler.Dispose();
@@ -423,16 +470,8 @@ public class BTaskManager : IAsyncDisposable
         }
         _daemonCts.Dispose();
 
-        // 2. Stop non-Critical tasks
-        var nonCriticalTasks = _taskMap.Values
-            .Where(t => t.Task.Level != BTaskLevel.Critical && t.Task.Status.IsActive())
-            .ToList();
-
-        foreach (var task in nonCriticalTasks)
-        {
-            _logger.LogInformation($"Stopping non-critical task: {task.Id}");
-            await task.Stop();
-        }
+        // 2. Stop non-Critical tasks (usually already asked, see PrepareForShutdown)
+        await PrepareForShutdown();
 
         // 3. Wait for Critical tasks to complete
         var criticalTasks = _taskMap.Values

--- a/src/abstractions/Bakabase.Abstractions/Services/IPathMarkService.cs
+++ b/src/abstractions/Bakabase.Abstractions/Services/IPathMarkService.cs
@@ -111,7 +111,13 @@ public interface IPathMarkService
     /// <summary>
     /// Preview matched paths for a path mark (without saving) with detailed information (resource layer, property values)
     /// </summary>
-    Task<List<PathMarkPreviewResult>> PreviewMatchedPaths(PathMarkPreviewRequest request);
+    /// <param name="ct">
+    /// Honoured down to the individual filesystem entry: previewing a mark rooted at a large
+    /// library is a full recursive walk, and without this it runs to completion even after the
+    /// caller has gone away.
+    /// </param>
+    Task<List<PathMarkPreviewResult>> PreviewMatchedPaths(PathMarkPreviewRequest request,
+        CancellationToken ct = default);
 
     /// <summary>
     /// Migrate all marks from old path to new path.

--- a/src/apps/Bakabase.Service/Components/Tasks/ResourceDataTask.cs
+++ b/src/apps/Bakabase.Service/Components/Tasks/ResourceDataTask.cs
@@ -81,6 +81,14 @@ public class ResourceDataTask : AbstractPredefinedBTaskBuilder
                     await coverProviderService.ResolveCoversAsync(resource, ct);
                 }
             }
+            // A cancelled phase is not a failed one. Swallowing it here turned a stop request
+            // into a warning and carried straight on to the next phase — and then to the next
+            // resource's phases — so the task only really stopped at the following yield point,
+            // several seconds of directory scanning and HTTP later.
+            catch (OperationCanceledException) when (ct.IsCancellationRequested)
+            {
+                throw;
+            }
             catch (Exception ex)
             {
                 logger.LogWarning(ex, "Failed to resolve covers for resource {ResourceId}", resource.Id);
@@ -102,6 +110,10 @@ public class ResourceDataTask : AbstractPredefinedBTaskBuilder
                     await playableItemProviderService.GetPlayableItemsAsync(resource, ct);
                 }
             }
+            catch (OperationCanceledException) when (ct.IsCancellationRequested)
+            {
+                throw;
+            }
             catch (Exception ex)
             {
                 logger.LogWarning(ex, "Failed to resolve playable items for resource {ResourceId}", resource.Id);
@@ -112,6 +124,11 @@ public class ResourceDataTask : AbstractPredefinedBTaskBuilder
             {
                 foreach (var link in resource.SourceLinks.Where(l => l.MetadataFetchedAt == null))
                 {
+                    // Each link is a network round trip, so a resource with several of them is
+                    // the longest stretch in the loop — check in between rather than only once
+                    // per resource.
+                    await args.YieldAsync();
+
                     var origin = link.Source switch
                     {
                         ResourceSource.Steam => DataOrigin.Steam,
@@ -172,6 +189,10 @@ public class ResourceDataTask : AbstractPredefinedBTaskBuilder
                             link.MetadataFetchedAt = DateTime.Now;
                             await sourceLinkService.Update(link);
                         }
+                    }
+                    catch (OperationCanceledException) when (ct.IsCancellationRequested)
+                    {
+                        throw;
                     }
                     catch (Exception ex)
                     {

--- a/src/apps/Bakabase.Service/Controllers/PathMarkController.cs
+++ b/src/apps/Bakabase.Service/Controllers/PathMarkController.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Bakabase.Abstractions.Models.Domain;
 using Bakabase.Abstractions.Models.Domain.Constants;
@@ -170,9 +171,10 @@ public class PathMarkController(IPathMarkService service, IPathMarkSyncService s
 
     [HttpPost("preview")]
     [SwaggerOperation(OperationId = "PreviewPathMarkMatchedPaths")]
-    public async Task<ListResponse<PathMarkPreviewResult>> PreviewMatchedPaths([FromBody] PathMarkPreviewRequest request)
+    public async Task<ListResponse<PathMarkPreviewResult>> PreviewMatchedPaths([FromBody] PathMarkPreviewRequest request,
+        CancellationToken ct)
     {
-        var results = await service.PreviewMatchedPaths(request);
+        var results = await service.PreviewMatchedPaths(request, ct);
         return new ListResponse<PathMarkPreviewResult>(results);
     }
 

--- a/src/apps/Bakabase/Components/ExitCoordinator.cs
+++ b/src/apps/Bakabase/Components/ExitCoordinator.cs
@@ -68,6 +68,18 @@ public sealed class ExitCoordinator(App app, AvaloniaGuiAdapter gui)
     private static readonly TimeSpan NoUiCriticalTaskTimeout = TimeSpan.FromSeconds(30);
 
     /// <summary>
+    /// How long a task that has been *asked* to stop gets to actually stop before the shutdown
+    /// moves on without it.
+    ///
+    /// Unlike the critical wait this is bounded: the task has already been told to go, so what is
+    /// left is only letting it reach its next checkpoint and release the DB and file handles it
+    /// holds before the container that owns them is disposed. A body that ignores cancellation
+    /// must not be able to make the app unquittable. Matches
+    /// <c>BTaskHandler.StopGraceTimeout</c>, which is where such a body already gets logged.
+    /// </summary>
+    private static readonly TimeSpan CancelledTaskDrainTimeout = TimeSpan.FromSeconds(10);
+
+    /// <summary>
     /// Ceiling on stopping the web host itself. Unlike background tasks this should always be
     /// quick; if a hosted service wedges, exiting must not become impossible.
     /// </summary>
@@ -589,7 +601,10 @@ public sealed class ExitCoordinator(App app, AvaloniaGuiAdapter gui)
                 Serilog.Log.Warning(e, "Failed to ask background tasks to stop while exiting");
             }
 
-            await WaitForCriticalTasksAsync(taskManager, setTasks, offerForceQuit, ct);
+            // Then let them finish stopping before anything they depend on is taken away. Stopping
+            // the host is what disposes the DB contexts, HTTP clients and file handles a task body
+            // is still holding between its last checkpoint and its next one.
+            await WaitForTasksToWindDownAsync(taskManager, setTasks, offerForceQuit, ct);
         }
 
         ct.ThrowIfCancellationRequested();
@@ -604,9 +619,10 @@ public sealed class ExitCoordinator(App app, AvaloniaGuiAdapter gui)
         using var stopCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
         stopCts.CancelAfter(HostStopTimeout);
 
-        // This is where the non-critical tasks are actually stopped, and it can take the whole
-        // fifteen seconds. Keep naming what is still running instead of clearing the list and
-        // leaving the user with a bare spinner for the longest part of the shutdown.
+        // Background work has normally gone quiet by now, but this can still take the whole fifteen
+        // seconds, and anything that outstayed its grace above is still listed. Keep naming what is
+        // running rather than clearing the list and leaving a bare spinner over the longest part of
+        // the shutdown.
         using var reporting = StartReportingActiveTasks(taskManager, setTasks);
 
         try
@@ -723,7 +739,23 @@ public sealed class ExitCoordinator(App app, AvaloniaGuiAdapter gui)
         await dispose;
     }
 
-    private static async Task WaitForCriticalTasksAsync(
+    /// <summary>
+    /// Waits for background work to actually go quiet, having just asked all of it to stop.
+    ///
+    /// Two waits in one loop, because the two kinds of task mean different things here:
+    /// <list type="bullet">
+    /// <item>Tasks that were cancelled were told to stop, so all that is left is letting them
+    /// reach their next checkpoint and release their DB and file handles before the container
+    /// holding those is disposed. Bounded by <see cref="CancelledTaskDrainTimeout"/>.</item>
+    /// <item>Critical tasks were deliberately <em>not</em> asked to stop — interrupting them is
+    /// what loses data — so that wait stays unbounded and the user gets "Quit now" rather than a
+    /// timer deciding for them.</item>
+    /// </list>
+    ///
+    /// Waiting here rather than letting the cancelled tasks unwind alongside the host stop is the
+    /// point: the host stop is what tears down the services they are still using.
+    /// </summary>
+    private static async Task WaitForTasksToWindDownAsync(
         BTaskManager taskManager,
         Action<ActiveTasks> setTasks,
         Func<bool> offerForceQuit,
@@ -737,8 +769,6 @@ public sealed class ExitCoordinator(App app, AvaloniaGuiAdapter gui)
             ActiveTasks active;
             try
             {
-                // Report everything that is running, but keep waiting only for the critical ones —
-                // those are the ones whose interruption loses data.
                 active = CollectActiveTasks(taskManager);
             }
             catch (Exception e)
@@ -749,10 +779,18 @@ public sealed class ExitCoordinator(App app, AvaloniaGuiAdapter gui)
 
             setTasks(active);
 
-            var remaining = active.Critical;
-
-            if (remaining == 0)
+            if (active.Total == 0)
             {
+                return;
+            }
+
+            // Nothing left but tasks that have had their grace and not taken it. Whatever they are
+            // doing between checkpoints, it is not worth holding the exit open for.
+            if (active.Critical == 0 && waited >= CancelledTaskDrainTimeout)
+            {
+                Serilog.Log.Warning(
+                    "Proceeding with shutdown after {Timeout} with {Count} task(s) still winding down",
+                    CancelledTaskDrainTimeout, active.Total);
                 return;
             }
 
@@ -760,14 +798,14 @@ public sealed class ExitCoordinator(App app, AvaloniaGuiAdapter gui)
             {
                 forceQuitOffered = offerForceQuit();
 
-                if (!forceQuitOffered && waited >= NoUiCriticalTaskTimeout)
+                if (!forceQuitOffered && active.Critical > 0 && waited >= NoUiCriticalTaskTimeout)
                 {
                     // No window came up, so there is nobody to ask and no button to press.
                     // Waiting on unbounded critical work would leave a process that cannot be
                     // quit; a bounded grace period is the lesser evil.
                     Serilog.Log.Warning(
                         "Proceeding with shutdown after {Timeout} with {Count} critical task(s) still active and no UI to ask",
-                        NoUiCriticalTaskTimeout, remaining);
+                        NoUiCriticalTaskTimeout, active.Critical);
                     return;
                 }
             }

--- a/src/apps/Bakabase/Components/ExitCoordinator.cs
+++ b/src/apps/Bakabase/Components/ExitCoordinator.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Avalonia.Controls;
+using Avalonia.Threading;
 using Bakabase.Abstractions.Components.Tasks;
 using Bakabase.Abstractions.Models.Domain.Constants;
 using Bakabase.Abstractions.Models.View;
@@ -45,6 +46,10 @@ public sealed class ExitCoordinator(App app, AvaloniaGuiAdapter gui)
     /// <summary>
     /// How long a shutdown may look instantaneous before we put a window on screen. Below
     /// this a progress window would be a flash of chrome; above it, silence reads as a hang.
+    ///
+    /// Only applies when there is nothing to report. If work is still in flight the window goes up
+    /// immediately: that is precisely the case where the user has just been told tasks are running
+    /// and would otherwise be left staring at an empty desktop wondering whether anything happened.
     /// </summary>
     private static readonly TimeSpan ProgressWindowDelay = TimeSpan.FromMilliseconds(400);
 
@@ -250,6 +255,29 @@ public sealed class ExitCoordinator(App app, AvaloniaGuiAdapter gui)
             active.Count(t => t.Level == BTaskLevel.Critical));
     }
 
+    /// <summary>
+    /// Everything running right now — or nothing, if the task manager cannot be reached. Used
+    /// before the wind-down starts, to decide whether the progress window is worth showing at all.
+    /// </summary>
+    private ActiveTasks TryCollectActiveTasks()
+    {
+        var taskManager = TryGetService<BTaskManager>();
+        if (taskManager == null)
+        {
+            return default;
+        }
+
+        try
+        {
+            return CollectActiveTasks(taskManager);
+        }
+        catch (Exception e)
+        {
+            Serilog.Log.Warning(e, "Failed to enumerate running tasks while exiting");
+            return default;
+        }
+    }
+
     /// <param name="Lines">The ones worth naming on screen.</param>
     /// <param name="Total">How many are running in total, which is what the count must report.</param>
     /// <param name="Critical">How many of those the shutdown is actually waiting for.</param>
@@ -299,44 +327,49 @@ public sealed class ExitCoordinator(App app, AvaloniaGuiAdapter gui)
 
     private async Task RunWindDownAsync()
     {
+        using var forceQuit = new CancellationTokenSource();
+        var progress = new ExitProgress(() =>
+        {
+            // ReSharper disable once AccessToDisposedClosure
+            try { forceQuit.Cancel(); } catch (ObjectDisposedException) { /* already gone */ }
+        });
+
+        // Whether anything is running decides how the window should be timed, and the answer is
+        // already available here — waiting ProgressWindowDelay to find out only delays the one
+        // case that needs the window.
+        progress.SetTasks(TryCollectActiveTasks());
+
+        if (progress.HasWorkToReport)
+        {
+            progress.TryShow();
+        }
+
+        // After the window, not before. Both of these are shell calls that can block the UI
+        // thread — deregistering the tray icon talks to Explorer — and anything that happens
+        // first is time the user spends looking at a desktop with nothing on it.
         app.SetTrayIconVisible(false);
         gui.Hide();
 
-        using var forceQuit = new CancellationTokenSource();
-        ExitProgressWindow? progress = null;
-
-        // The window only appears once the shutdown has proven slow, by which time the phase has
-        // usually already moved on. Remembering the latest report lets the window open showing where
-        // the shutdown actually is, rather than the heading it was built with.
-        var latestPhase = ExitStrings.ClosingStoppingTasks;
-        var latestTasks = default(ActiveTasks);
-
         try
         {
-            var windDown = WindDownAsync(
-                phase =>
-                {
-                    latestPhase = phase;
-                    progress?.SetPhase(phase);
-                },
-                tasks =>
-                {
-                    latestTasks = tasks;
-                    progress?.SetRemainingTasks(tasks.Lines, tasks.Total);
-                },
-                () =>
-                {
-                    progress?.ShowForceQuit();
-                    return progress != null;
-                },
-                forceQuit.Token);
+            // On the thread pool, deliberately. An async method runs inline on its caller until
+            // its first pending await, and IHost.StopAsync opens by firing ApplicationStopping —
+            // whose callbacks run synchronously on that thread, SignalR's connection manager
+            // (tearing down the WebView's hub socket) among them. Run inline on the UI thread,
+            // that froze the dispatcher for seconds at a time, so the progress window could not be
+            // put on screen until the work it exists to narrate was already over. Everything below
+            // reports through ExitProgress, which marshals to the UI thread itself.
+            var windDown = Task.Run(() => WindDownAsync(
+                progress.SetPhase,
+                progress.SetTasks,
+                progress.OfferForceQuit,
+                forceQuit.Token));
 
-            // Only put a window on screen if the shutdown is slow enough to need one.
-            if (await Task.WhenAny(windDown, Task.Delay(ProgressWindowDelay)) != windDown)
+            // Nothing to report, so only put a window on screen if the shutdown proves slow.
+            if (!progress.ShowAttempted &&
+                await Task.WhenAny(windDown, Task.Delay(ProgressWindowDelay)) != windDown)
             {
-                progress = TryShowProgressWindow(forceQuit);
-                progress?.SetPhase(latestPhase);
-                progress?.SetRemainingTasks(latestTasks.Lines ?? [], latestTasks.Total);
+                progress.TryShow();
             }
 
             await windDown;
@@ -347,42 +380,172 @@ public sealed class ExitCoordinator(App app, AvaloniaGuiAdapter gui)
         }
         finally
         {
-            if (progress != null)
-            {
-                try
-                {
-                    progress.AllowClose();
-                    progress.Close();
-                }
-                catch (Exception e)
-                {
-                    Serilog.Log.Warning(e, "Failed to close the shutdown progress window");
-                }
-            }
+            progress.Close();
         }
     }
 
     /// <summary>
-    /// A display that has gone away (headless session, X11 dropped, compositor restart) must
-    /// not abort the wind-down — the user just does not get to watch it or force it along.
+    /// Owns the shutdown progress window and the last thing the wind-down had to say.
+    ///
+    /// The two live on different threads — the wind-down reports from the thread pool, the window
+    /// may only be created and closed on the UI thread, and either can come first — so what has
+    /// been reported is kept here and replayed into the window if and when one appears.
     /// </summary>
-    private static ExitProgressWindow? TryShowProgressWindow(CancellationTokenSource forceQuit)
+    private sealed class ExitProgress(Action onForceQuitRequested)
     {
-        try
+        private readonly object _lock = new();
+        private ExitProgressWindow? _window;
+        private bool _showAttempted;
+        private string _phase = ExitStrings.ClosingStoppingTasks;
+        private ActiveTasks _tasks;
+        private bool _forceQuitOffered;
+
+        /// <summary>Whether a window has been asked for — successfully or not.</summary>
+        public bool ShowAttempted
         {
-            var window = new ExitProgressWindow();
-            window.ForceQuitRequested += () =>
+            get
             {
-                // ReSharper disable once AccessToDisposedClosure
-                try { forceQuit.Cancel(); } catch (ObjectDisposedException) { /* already gone */ }
-            };
-            window.Show();
-            return window;
+                lock (_lock)
+                {
+                    return _showAttempted;
+                }
+            }
         }
-        catch (Exception e)
+
+        public bool HasWorkToReport
         {
-            Serilog.Log.Warning(e, "Could not show the shutdown progress window");
-            return null;
+            get
+            {
+                lock (_lock)
+                {
+                    return _tasks.Total > 0;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Creates the window and replays whatever has been reported so far. Must be called on the
+        /// UI thread, and only ever tries once: a display that has gone away (headless session,
+        /// X11 dropped, compositor restart) must not abort the wind-down — the user just does not
+        /// get to watch it or force it along.
+        /// </summary>
+        public void TryShow()
+        {
+            lock (_lock)
+            {
+                if (_showAttempted)
+                {
+                    return;
+                }
+
+                _showAttempted = true;
+            }
+
+            ExitProgressWindow window;
+
+            try
+            {
+                window = new ExitProgressWindow();
+                window.ForceQuitRequested += onForceQuitRequested;
+                window.Show();
+            }
+            catch (Exception e)
+            {
+                Serilog.Log.Warning(e, "Could not show the shutdown progress window");
+                return;
+            }
+
+            // Adopt and replay under the same lock: a report landing from the wind-down in between
+            // would reach the window first and then be overwritten by this (older) replay.
+            lock (_lock)
+            {
+                _window = window;
+
+                window.SetPhase(_phase);
+                window.SetRemainingTasks(_tasks.Lines ?? [], _tasks.Total);
+
+                if (_forceQuitOffered)
+                {
+                    window.ShowForceQuit();
+                }
+            }
+        }
+
+        // Recording and forwarding stay under the lock throughout, so what the window is told can
+        // never get out of order with what is remembered for a later replay. The window's own
+        // setters only marshal to the UI thread, so nothing here waits on it.
+
+        public void SetPhase(string phase)
+        {
+            lock (_lock)
+            {
+                _phase = phase;
+                _window?.SetPhase(phase);
+            }
+        }
+
+        public void SetTasks(ActiveTasks tasks)
+        {
+            lock (_lock)
+            {
+                _tasks = tasks;
+                _window?.SetRemainingTasks(tasks.Lines ?? [], tasks.Total);
+            }
+        }
+
+        /// <returns>Whether there is a window to offer it on.</returns>
+        public bool OfferForceQuit()
+        {
+            lock (_lock)
+            {
+                _forceQuitOffered = true;
+                _window?.ShowForceQuit();
+                return _window != null;
+            }
+        }
+
+        /// <summary>Takes the window down. A no-op when none was ever shown.</summary>
+        public void Close()
+        {
+            ExitProgressWindow? window;
+
+            lock (_lock)
+            {
+                window = _window;
+                _window = null;
+            }
+
+            if (window == null)
+            {
+                return;
+            }
+
+            void CloseIt()
+            {
+                window.AllowClose();
+                window.Close();
+            }
+
+            try
+            {
+                // Synchronously, not posted: the caller ends the Avalonia lifetime straight after
+                // this, and a window that has not been told closing is allowed cancels its own
+                // Closing event — which would cancel the app's shutdown along with it. Bounded,
+                // because a dispatcher that has already gone must not make the app unquittable.
+                if (Dispatcher.UIThread.CheckAccess())
+                {
+                    CloseIt();
+                }
+                else
+                {
+                    Dispatcher.UIThread.Invoke(CloseIt, DispatcherPriority.Send,
+                        CancellationToken.None, TimeSpan.FromSeconds(2));
+                }
+            }
+            catch (Exception e)
+            {
+                Serilog.Log.Warning(e, "Failed to close the shutdown progress window");
+            }
         }
     }
 
@@ -410,6 +573,22 @@ public sealed class ExitCoordinator(App app, AvaloniaGuiAdapter gui)
         if (taskManager != null)
         {
             setPhase(ExitStrings.ClosingStoppingTasks);
+
+            // Ask first, wait second. Non-critical tasks used to be cancelled only by
+            // BTaskManager.DisposeAsync — which runs *after* the host has stopped, so for the
+            // whole of that wait (up to HostStopTimeout) nothing had told them to stop and the
+            // window showed them still working: "Preparing resource data (17%)" ticking over to
+            // 18% ten seconds later, as if the shutdown were waiting for the task to finish.
+            try
+            {
+                await taskManager.PrepareForShutdown();
+            }
+            catch (Exception e)
+            {
+                // Best-effort: whatever refuses to be asked is still cancelled by disposal.
+                Serilog.Log.Warning(e, "Failed to ask background tasks to stop while exiting");
+            }
+
             await WaitForCriticalTasksAsync(taskManager, setTasks, offerForceQuit, ct);
         }
 

--- a/src/legacy/Bakabase.InsideWorld.Business/Components/CoverDiscoverer.cs
+++ b/src/legacy/Bakabase.InsideWorld.Business/Components/CoverDiscoverer.cs
@@ -1,5 +1,6 @@
 ﻿using System.IO;
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -41,10 +42,29 @@ public class CoverDiscoverer(ILoggerFactory loggerFactory, FfMpegService ffMpegS
             FileInfo[] files;
             using (MiniProfiler.Current.Step("EnumerateFiles"))
             {
+                ct.ThrowIfCancellationRequested();
+
                 var attr = File.GetAttributes(path);
-                files = attr.HasFlag(FileAttributes.Directory)
-                    ? new DirectoryInfo(path).GetFiles("*.*", SearchOption.AllDirectories)
-                    : new[] { new FileInfo(path) };
+                if (attr.HasFlag(FileAttributes.Directory))
+                {
+                    // Enumerate lazily and check per entry rather than calling GetFiles: a
+                    // recursive walk of a large resource folder is the longest uninterruptible
+                    // stretch on this path, and a stop request — the app exiting included — used
+                    // to have to wait the whole of it out before anything could observe it.
+                    var found = new List<FileInfo>();
+                    foreach (var file in new DirectoryInfo(path)
+                                 .EnumerateFiles("*.*", SearchOption.AllDirectories))
+                    {
+                        ct.ThrowIfCancellationRequested();
+                        found.Add(file);
+                    }
+
+                    files = found.ToArray();
+                }
+                else
+                {
+                    files = [new FileInfo(path)];
+                }
             }
 
             using (MiniProfiler.Current.Step($"SortFiles ({files.Length} files)"))

--- a/src/legacy/Bakabase.InsideWorld.Business/Components/Providers/Cover/LocalFileCoverProvider.cs
+++ b/src/legacy/Bakabase.InsideWorld.Business/Components/Providers/Cover/LocalFileCoverProvider.cs
@@ -96,6 +96,13 @@ public class LocalFileCoverProvider : ICoverProvider
                 coverPath = await image.SaveAsThumbnail(pathWithoutExt, ct);
             }
         }
+        // An interrupted discovery found nothing yet; it did not establish that there is nothing.
+        // Falling through would mark the cache ready with no cover, so the resource would never be
+        // looked at again.
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
+        }
         catch (Exception e)
         {
             _logger.LogWarning(e, "Failed to discover/save cover for resource {ResourceId}", resource.Id);

--- a/src/legacy/Bakabase.InsideWorld.Business/Components/Providers/PlayableItem/LocalFilePlayableItemProvider.cs
+++ b/src/legacy/Bakabase.InsideWorld.Business/Components/Providers/PlayableItem/LocalFilePlayableItemProvider.cs
@@ -123,7 +123,17 @@ public class LocalFilePlayableItemProvider : IPlayableItemProvider
                 {
                     try
                     {
-                        files = Directory.EnumerateFiles(resource.Path, "*", SearchOption.AllDirectories).ToList();
+                        // Checked per file, not once around the walk: a recursive enumeration of
+                        // a large resource folder is the longest uninterruptible stretch in the
+                        // "prepare resource data" task, and until this existed a stop request
+                        // (app exit included) had to wait the whole scan out.
+                        files = [];
+                        foreach (var file in Directory.EnumerateFiles(resource.Path, "*",
+                                     SearchOption.AllDirectories))
+                        {
+                            ct.ThrowIfCancellationRequested();
+                            files.Add(file);
+                        }
                     }
                     catch (DirectoryNotFoundException)
                     {
@@ -149,6 +159,13 @@ public class LocalFilePlayableItemProvider : IPlayableItemProvider
 
                 playableFiles = result.Select(f => f.StandardizePath()!).ToArray();
             }
+        }
+        // An interrupted scan discovered nothing; it did not find nothing. Falling through to the
+        // cache write below would persist "this resource has no playable files" — a valid cached
+        // result that stops it ever being scanned again.
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
         }
         catch (Exception e)
         {

--- a/src/legacy/Bakabase.InsideWorld.Business/Components/Resolvers/FileSystemResolver.cs
+++ b/src/legacy/Bakabase.InsideWorld.Business/Components/Resolvers/FileSystemResolver.cs
@@ -109,7 +109,7 @@ public class FileSystemResolver : IResourceResolver
                     config.Extensions = merged.Distinct().ToList();
                 }
 
-                var matchedPaths = GetMatchingPathsForResourceMark(mark.Path, config, regexCache);
+                var matchedPaths = GetMatchingPathsForResourceMark(mark.Path, config, regexCache, ct);
 
                 foreach (var path in matchedPaths)
                 {
@@ -132,7 +132,9 @@ public class FileSystemResolver : IResourceResolver
                     });
                 }
             }
-            catch (Exception ex)
+            // Both arms rethrow; the filter is only so a stop request does not get reported as a
+            // mark that failed to process.
+            catch (Exception ex) when (ex is not OperationCanceledException || !ct.IsCancellationRequested)
             {
                 _logger.LogWarning(ex, "[FileSystemResolver] Failed to process mark {MarkId} on path {Path}",
                     mark.Id, mark.Path);
@@ -145,10 +147,17 @@ public class FileSystemResolver : IResourceResolver
 
     #region Discovery Helpers
 
+    /// <param name="ct">
+    /// Threaded all the way down to the individual filesystem entry. A mark rooted at a large
+    /// library expands into a full recursive walk, which is by far the longest stretch of this
+    /// resolver — leaving it uncancellable meant a stop request (the app exiting included) sat
+    /// behind the whole scan before <see cref="DiscoverFromMarks"/> got to its next checkpoint.
+    /// </param>
     private List<string> GetMatchingPathsForResourceMark(
         string rootPath,
         ResourceMarkConfig config,
-        ConcurrentDictionary<string, Regex> regexCache)
+        ConcurrentDictionary<string, Regex> regexCache,
+        CancellationToken ct)
     {
         var matchedPaths = new List<string>();
         var normalizedRoot = rootPath.StandardizePath()!;
@@ -170,7 +179,8 @@ public class FileSystemResolver : IResourceResolver
                 }
                 else
                 {
-                    initialMatches = GetEntriesAtLayer(normalizedRoot, layer, config.FsTypeFilter, config.Extensions);
+                    initialMatches = GetEntriesAtLayer(normalizedRoot, layer, config.FsTypeFilter, config.Extensions,
+                        ct);
                 }
             }
             else if (config.MatchMode == PathMatchMode.Regex && !string.IsNullOrEmpty(config.Regex))
@@ -184,7 +194,7 @@ public class FileSystemResolver : IResourceResolver
                 }
 
                 var regex = GetOrCreateRegex(regexPattern, regexCache);
-                var entries = GetAllEntries(normalizedRoot, config.FsTypeFilter, config.Extensions);
+                var entries = GetAllEntries(normalizedRoot, config.FsTypeFilter, config.Extensions, ct);
                 initialMatches = new List<string>();
 
                 foreach (var entry in entries)
@@ -211,13 +221,22 @@ public class FileSystemResolver : IResourceResolver
                 matchedPaths.AddRange(initialMatches);
                 foreach (var match in initialMatches)
                 {
+                    // Each iteration is a whole recursive walk of its own.
+                    ct.ThrowIfCancellationRequested();
+
                     if (Directory.Exists(match))
                     {
-                        var subdirEntries = GetAllEntries(match, config.FsTypeFilter, config.Extensions);
+                        var subdirEntries = GetAllEntries(match, config.FsTypeFilter, config.Extensions, ct);
                         matchedPaths.AddRange(subdirEntries);
                     }
                 }
             }
+        }
+        // Cancellation is not an access error. These catches exist to let an unreadable directory
+        // be skipped rather than abort the mark, and a bare one swallows the stop request too.
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
         }
         catch
         {
@@ -228,7 +247,7 @@ public class FileSystemResolver : IResourceResolver
     }
 
     private static List<string> GetAllEntries(string rootPath, PathFilterFsType? fsTypeFilter,
-        List<string>? extensions)
+        List<string>? extensions, CancellationToken ct)
     {
         var entries = new List<string>();
 
@@ -238,6 +257,7 @@ public class FileSystemResolver : IResourceResolver
             {
                 foreach (var dir in Directory.EnumerateDirectories(rootPath, "*", SearchOption.AllDirectories))
                 {
+                    ct.ThrowIfCancellationRequested();
                     entries.Add(dir.StandardizePath()!);
                 }
             }
@@ -247,6 +267,8 @@ public class FileSystemResolver : IResourceResolver
                 var extensionSet = extensions?.ToHashSet(StringComparer.OrdinalIgnoreCase);
                 foreach (var file in Directory.EnumerateFiles(rootPath, "*", SearchOption.AllDirectories))
                 {
+                    ct.ThrowIfCancellationRequested();
+
                     if (extensionSet == null || extensionSet.Count == 0 ||
                         extensionSet.Any(ext => file.EndsWith(ext, StringComparison.OrdinalIgnoreCase)))
                     {
@@ -254,6 +276,10 @@ public class FileSystemResolver : IResourceResolver
                     }
                 }
             }
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
         }
         catch
         {
@@ -264,7 +290,7 @@ public class FileSystemResolver : IResourceResolver
     }
 
     private static List<string> GetEntriesAtLayer(string rootPath, int layer, PathFilterFsType? fsTypeFilter,
-        List<string>? extensions)
+        List<string>? extensions, CancellationToken ct)
     {
         var entries = new List<string>();
 
@@ -277,6 +303,8 @@ public class FileSystemResolver : IResourceResolver
                 var nextPaths = new List<string>();
                 foreach (var path in currentPaths)
                 {
+                    ct.ThrowIfCancellationRequested();
+
                     try
                     {
                         nextPaths.AddRange(Directory.EnumerateDirectories(path));
@@ -314,6 +342,10 @@ public class FileSystemResolver : IResourceResolver
             {
                 entries.AddRange(currentPaths);
             }
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
         }
         catch
         {
@@ -470,11 +502,21 @@ public class FileSystemResolver : IResourceResolver
             .Select(e => e.StartsWith('.') ? e : $".{e}")
             .ToHashSet(StringComparer.OrdinalIgnoreCase);
 
-        var files = Directory.Exists(resource.Path)
-            ? Directory.EnumerateFiles(resource.Path, "*", SearchOption.AllDirectories)
-            : [];
+        // Per entry, for the same reason as the mark walks above: a resource directory can be
+        // arbitrarily large, and this is the only long stretch between the caller's checkpoints.
+        var result = new List<string>();
+        if (Directory.Exists(resource.Path))
+        {
+            foreach (var file in Directory.EnumerateFiles(resource.Path, "*", SearchOption.AllDirectories))
+            {
+                ct.ThrowIfCancellationRequested();
 
-        var result = files.Where(f => extensions.Contains(Path.GetExtension(f))).ToList();
+                if (extensions.Contains(Path.GetExtension(file)))
+                {
+                    result.Add(file);
+                }
+            }
+        }
 
         // Apply file name pattern filter if configured
         if (!string.IsNullOrEmpty(playableFileOptions.FileNamePattern))

--- a/src/legacy/Bakabase.InsideWorld.Business/Services/PathMarkService.cs
+++ b/src/legacy/Bakabase.InsideWorld.Business/Services/PathMarkService.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Text.RegularExpressions;
+using System.Threading;
 using System.Threading.Tasks;
 using Bakabase.Abstractions.Extensions;
 using Bakabase.Abstractions.Models.Db;
@@ -495,7 +496,8 @@ public class PathMarkService<TDbContext>(
         return allMarks.Count;
     }
 
-    public async Task<List<PathMarkPreviewResult>> PreviewMatchedPaths(PathMarkPreviewRequest request)
+    public async Task<List<PathMarkPreviewResult>> PreviewMatchedPaths(PathMarkPreviewRequest request,
+        CancellationToken ct = default)
     {
         var rootPath = request.Path.StandardizePath()!;
         var results = new List<PathMarkPreviewResult>();
@@ -570,7 +572,8 @@ public class PathMarkService<TDbContext>(
         }
 
         // Step 3: Get matched paths using common logic
-        var matchedPaths = GetMatchingPaths(rootPath, matchMode, layer, regex, applyScope, fsTypeFilter, extensions);
+        var matchedPaths = GetMatchingPaths(rootPath, matchMode, layer, regex, ct, applyScope, fsTypeFilter,
+            extensions);
 
         var rootSegments = rootPath.Split(new[] { Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar },
             StringSplitOptions.RemoveEmptyEntries);
@@ -624,6 +627,7 @@ public class PathMarkService<TDbContext>(
     /// Common path matching logic for all mark types
     /// </summary>
     private List<string> GetMatchingPaths(string rootPath, PathMatchMode matchMode, int? layer, string? regex,
+        CancellationToken ct,
         PathMarkApplyScope? applyScope = null, PathFilterFsType? fsTypeFilter = null, List<string>? extensions = null)
     {
         var matchedPaths = new List<string>();
@@ -637,12 +641,12 @@ public class PathMarkService<TDbContext>(
                 if (layer == -1)
                 {
                     // All layers - recursively get all directories/files
-                    matchedPaths.AddRange(GetAllEntries(rootPath, fsTypeFilter, extensions));
+                    matchedPaths.AddRange(GetAllEntries(rootPath, fsTypeFilter, extensions, ct));
                 }
                 else
                 {
                     // Specific layer
-                    matchedPaths.AddRange(GetEntriesAtLayer(rootPath, layer.Value, fsTypeFilter, extensions));
+                    matchedPaths.AddRange(GetEntriesAtLayer(rootPath, layer.Value, fsTypeFilter, extensions, ct));
                 }
             }
             else if (matchMode == PathMatchMode.Regex && !string.IsNullOrEmpty(regex))
@@ -659,7 +663,7 @@ public class PathMarkService<TDbContext>(
                 }
 
                 var regexObj = new Regex(regexPattern, RegexOptions.IgnoreCase);
-                var entries = GetAllEntries(rootPath, fsTypeFilter, extensions);
+                var entries = GetAllEntries(rootPath, fsTypeFilter, extensions, ct);
 
                 foreach (var entry in entries)
                 {
@@ -671,6 +675,12 @@ public class PathMarkService<TDbContext>(
                     }
                 }
             }
+        }
+        // Cancellation is not an access error. These catches exist to let an unreadable directory
+        // be skipped rather than fail the preview, and a broad one swallows the abort too.
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
         }
         catch (Exception)
         {
@@ -803,27 +813,42 @@ public class PathMarkService<TDbContext>(
     }
 
 
-    private List<string> GetAllEntries(string rootPath, PathFilterFsType? fsTypeFilter, List<string>? extensions)
+    private List<string> GetAllEntries(string rootPath, PathFilterFsType? fsTypeFilter, List<string>? extensions,
+        CancellationToken ct)
     {
         var entries = new List<string>();
 
         try
         {
+            // Enumerate lazily and check per entry rather than calling Get*: the walk itself is the
+            // long part, so materialising it first would leave nothing for the check to shorten.
             if (fsTypeFilter == null || fsTypeFilter == PathFilterFsType.Directory)
             {
-                entries.AddRange(Directory.GetDirectories(rootPath, "*", SearchOption.AllDirectories));
+                foreach (var dir in Directory.EnumerateDirectories(rootPath, "*", SearchOption.AllDirectories))
+                {
+                    ct.ThrowIfCancellationRequested();
+                    entries.Add(dir);
+                }
             }
 
             if (fsTypeFilter == null || fsTypeFilter == PathFilterFsType.File)
             {
-                var files = Directory.GetFiles(rootPath, "*", SearchOption.AllDirectories);
-                if (extensions != null && extensions.Count > 0)
+                var hasExtensionFilter = extensions is {Count: > 0};
+                foreach (var file in Directory.EnumerateFiles(rootPath, "*", SearchOption.AllDirectories))
                 {
-                    files = files.Where(f => extensions.Any(ext =>
-                        f.EndsWith(ext, StringComparison.OrdinalIgnoreCase))).ToArray();
+                    ct.ThrowIfCancellationRequested();
+
+                    if (!hasExtensionFilter ||
+                        extensions!.Any(ext => file.EndsWith(ext, StringComparison.OrdinalIgnoreCase)))
+                    {
+                        entries.Add(file);
+                    }
                 }
-                entries.AddRange(files);
             }
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
         }
         catch (Exception)
         {
@@ -833,7 +858,8 @@ public class PathMarkService<TDbContext>(
         return entries.Select(x => x.StandardizePath()!).ToList();
     }
 
-    private List<string> GetEntriesAtLayer(string rootPath, int layer, PathFilterFsType? fsTypeFilter, List<string>? extensions)
+    private List<string> GetEntriesAtLayer(string rootPath, int layer, PathFilterFsType? fsTypeFilter,
+        List<string>? extensions, CancellationToken ct)
     {
         var entries = new List<string>();
 
@@ -846,6 +872,8 @@ public class PathMarkService<TDbContext>(
                 var nextPaths = new List<string>();
                 foreach (var path in currentPaths)
                 {
+                    ct.ThrowIfCancellationRequested();
+
                     try
                     {
                         nextPaths.AddRange(Directory.GetDirectories(path));
@@ -880,6 +908,10 @@ public class PathMarkService<TDbContext>(
             {
                 entries.AddRange(currentPaths);
             }
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
         }
         catch (Exception)
         {

--- a/src/tests/Bakabase.Tests/BTaskShutdownTests.cs
+++ b/src/tests/Bakabase.Tests/BTaskShutdownTests.cs
@@ -1,0 +1,110 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Bakabase.Abstractions.Components.Tasks;
+using Bakabase.Abstractions.Models.Domain.Constants;
+using Bakabase.TestKit.Utils;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Bakabase.Tests;
+
+/// <summary>
+/// Covers <see cref="BTaskManager.PrepareForShutdown"/> — the step the exit flow uses to ask
+/// background work to wind down the moment the user commits to quitting, rather than waiting for
+/// disposal (which only runs once the web host has stopped, many seconds later).
+/// </summary>
+[TestClass]
+public sealed class BTaskShutdownTests
+{
+    private IServiceProvider _sp = null!;
+    private BTaskManager _btm = null!;
+
+    [TestInitialize]
+    public async Task Setup()
+    {
+        _sp = await TestServiceBuilder.BuildServiceProvider();
+        _btm = _sp.GetRequiredService<BTaskManager>();
+    }
+
+    private async Task WaitForStatus(string id, BTaskStatus status, TimeSpan timeout)
+    {
+        var deadline = DateTime.UtcNow + timeout;
+        while (DateTime.UtcNow < deadline)
+        {
+            if (_btm.GetTaskViewModel(id)?.Status == status) return;
+            await Task.Delay(10);
+        }
+
+        throw new TimeoutException(
+            $"Task {id} did not reach {status} within {timeout} " +
+            $"(last seen: {_btm.GetTaskViewModel(id)?.Status.ToString() ?? "gone"})");
+    }
+
+    [TestMethod]
+    public async Task PrepareForShutdown_CancelsRunningNonCriticalTask()
+    {
+        const string id = "shutdown-non-critical";
+        var started = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        await _btm.Enqueue(BTaskBuilder.Create(id)
+            .Run(async args =>
+            {
+                started.TrySetResult();
+                await Task.Delay(Timeout.Infinite, args.CancellationToken);
+            }));
+        await _btm.Start(id);
+        await started.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        await _btm.PrepareForShutdown();
+
+        await WaitForStatus(id, BTaskStatus.Cancelled, TimeSpan.FromSeconds(5));
+    }
+
+    [TestMethod]
+    public async Task PrepareForShutdown_LeavesCriticalTaskRunning()
+    {
+        const string id = "shutdown-critical";
+        var started = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        await _btm.Enqueue(BTaskBuilder.Create(id)
+            .Critical()
+            .Run(async args =>
+            {
+                started.TrySetResult();
+                await Task.Delay(Timeout.Infinite, args.CancellationToken);
+            }));
+        await _btm.Start(id);
+        await started.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        await _btm.PrepareForShutdown();
+
+        // Interrupting a critical task is what loses data — the exit flow waits for these instead,
+        // and offers the user "Quit now" if the wait drags on.
+        await Task.Delay(300);
+        Assert.AreEqual(BTaskStatus.Running, _btm.GetTaskViewModel(id)!.Status);
+
+        await _btm.Stop(id);
+    }
+
+    [TestMethod]
+    public async Task PrepareForShutdown_IsIdempotent()
+    {
+        const string id = "shutdown-twice";
+        var started = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        await _btm.Enqueue(BTaskBuilder.Create(id)
+            .Run(async args =>
+            {
+                started.TrySetResult();
+                await Task.Delay(Timeout.Infinite, args.CancellationToken);
+            }));
+        await _btm.Start(id);
+        await started.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        // DisposeAsync runs the same step, so the exit path always calls it twice.
+        await _btm.PrepareForShutdown();
+        await _btm.PrepareForShutdown();
+
+        await WaitForStatus(id, BTaskStatus.Cancelled, TimeSpan.FromSeconds(5));
+    }
+}


### PR DESCRIPTION
## Summary

Refactors the application shutdown flow to make it more responsive and give users better feedback during exit. The key improvement is asking background tasks to stop *immediately* when the user commits to quitting, rather than waiting for the web host to stop (which can take many seconds). This eliminates the confusing experience of watching task progress tick over while the app appears to be hanging.

## Key Changes

- **New `BTaskManager.PrepareForShutdown()` method**: Called the moment the user commits to quitting. Stops the daemon from promoting new tasks and asks all non-Critical tasks to stop immediately. Critical tasks are deliberately not interrupted (since that loses data). This is idempotent and safe to call before `DisposeAsync()`.

- **Refactored `ExitCoordinator` shutdown flow**:
  - Introduces `ExitProgress` class to own the progress window and coordinate state between the wind-down (running on thread pool) and UI thread
  - Calls `PrepareForShutdown()` before waiting for tasks, so cancellation requests reach tasks immediately
  - Moves UI operations (hiding tray icon, hiding main window) to after the progress window is shown, eliminating the "staring at empty desktop" moment
  - Runs the wind-down on the thread pool to prevent UI thread blocking during host shutdown (which fires `ApplicationStopping` callbacks synchronously)
  - Shows the progress window immediately if there's work to report, only delays it if nothing is running

- **New `CancelledTaskDrainTimeout` (10s)**: Bounded grace period for cancelled tasks to reach their next checkpoint and release DB/file handles before the container is disposed. Prevents uncooperative tasks from making the app unquittable.

- **Cancellation token threading**: Propagates `CancellationToken` through filesystem operations (directory walks, file enumeration) in:
  - `FileSystemResolver.GetMatchingPathsForResourceMark()`
  - `PathMarkService.PreviewMatchedPaths()` and `GetMatchingPaths()`
  - `CoverDiscoverer` file enumeration
  - `LocalFilePlayableItemProvider` file enumeration
  
  This makes long-running recursive walks cancellable, so stop requests don't get stuck behind multi-second directory scans.

- **Cancellation exception handling**: Added explicit `catch (OperationCanceledException) when (ct.IsCancellationRequested)` blocks in several places to distinguish cancellation from other errors, preventing stop requests from being misreported as failures.

- **New test suite `BTaskShutdownTests`**: Covers `PrepareForShutdown()` behavior — verifies non-critical tasks are cancelled, critical tasks are left running, and the method is idempotent.

- **Updated `.claude/rules/btask.md`**: Documents the new shutdown sequence, timeout values, and the deliberate choice to keep all current tasks at `BTaskLevel.Default` (stoppable).

## Implementation Details

- The `ExitProgress` class uses a lock to coordinate state between the thread-pool wind-down and UI thread, ensuring reports are never out of order and the window replays the latest state if it appears after reporting has started.
- The progress window is shown immediately if tasks are running (since the user was just told they are), but delayed by 400ms if nothing is running (to avoid a flash of chrome for quick shutdowns).
- `Dispatcher.UIThread.Invoke()` with a 2-second timeout is used to close the window, ensuring a missing dispatcher doesn't make the app unquittable.
- The wind-down now explicitly checks for cancellation at loop boundaries in filesystem walks, rather than relying on a single check around the entire operation.

https://claude.ai/code/session_01X7CMKAwMscZNbiX6CNbKBq