### PR TITLE
fix(path-mark): repair legacy reference values and filtering

### DIFF
--- a/src/abstractions/Bakabase.Abstractions/Models/Db/PropertyMarkEffectDbModel.cs
+++ b/src/abstractions/Bakabase.Abstractions/Models/Db/PropertyMarkEffectDbModel.cs
@@ -32,9 +32,8 @@ public record PropertyMarkEffectDbModel
     public int ResourceId { get; set; }
 
     /// <summary>
-    /// The value that was set (serialized).
-    /// For multi-select: comma-separated values.
-    /// For MediaLibrary: media library ID as string.
+    /// For custom properties, the value serialized with the property's BizValueType.
+    /// For MediaLibrary effects, the media library ID as a string.
     /// </summary>
     public string? Value { get; set; }
 

--- a/src/abstractions/Bakabase.Abstractions/Models/Domain/PropertyMarkEffect.cs
+++ b/src/abstractions/Bakabase.Abstractions/Models/Domain/PropertyMarkEffect.cs
@@ -12,6 +12,11 @@ public class PropertyMarkEffect
     public PropertyPool PropertyPool { get; set; }
     public int PropertyId { get; set; }
     public int ResourceId { get; set; }
+
+    /// <summary>
+    /// For custom properties, the value serialized with the property's BizValueType.
+    /// Internal media-library effects store the media library id as a string.
+    /// </summary>
     public string? Value { get; set; }
     public int Priority { get; set; }
     public DateTime CreatedAt { get; set; }

--- a/src/legacy/Bakabase.InsideWorld.Business/Services/PathMarkSyncService.cs
+++ b/src/legacy/Bakabase.InsideWorld.Business/Services/PathMarkSyncService.cs
@@ -114,6 +114,25 @@ public class PathMarkSyncService : ScopedService
 
             // Load all pending Property and MediaLibrary marks
             var allMarks = await _pathMarkService.GetAll();
+            foreach (var mark in allMarks)
+            {
+                ctx.PathMarksById[mark.Id] = mark;
+                if (mark.Type == PathMarkType.Property)
+                {
+                    try
+                    {
+                        ctx.PropertyMarkConfigsByMarkId[mark.Id] =
+                            JsonConvert.DeserializeObject<PropertyMarkConfig>(mark.ConfigJson);
+                    }
+                    catch
+                    {
+                        // The mark's normal collection path will report malformed config
+                        // if it is pending. For a context mark, it simply cannot help
+                        // disambiguate a historical reference value.
+                        ctx.PropertyMarkConfigsByMarkId[mark.Id] = null;
+                    }
+                }
+            }
             var pendingMarks = allMarks
                 .Where(m => m.SyncStatus is PathMarkSyncStatus.Pending or PathMarkSyncStatus.PendingDelete)
                 .Where(m => m.Type is PathMarkType.Property or PathMarkType.MediaLibrary)
@@ -158,7 +177,9 @@ public class PathMarkSyncService : ScopedService
 
             // Load old effects from already-synced Property/MediaLibrary marks as
             // *context only* — used to recompute combined values and to protect
-            // mappings contributed by other marks. Never written or deleted.
+            // mappings contributed by other marks. They are never deleted here;
+            // legacy DB-valued reference effects can be normalized to the canonical
+            // business-value representation during final-state computation.
             var contextMarkIds = allMarks
                 .Where(m => m.SyncStatus == PathMarkSyncStatus.Synced
                             && m.Type is PathMarkType.Property or PathMarkType.MediaLibrary)
@@ -361,7 +382,7 @@ public class PathMarkSyncService : ScopedService
                 value = sharedValue!;
             }
 
-            var valueString = value is string s ? s : System.Text.Json.JsonSerializer.Serialize(value, System.Text.Json.JsonSerializerOptions.Web);
+            var valueString = SerializePropertyMarkEffectValue(value);
 
             // Record the effect
             ctx.CollectedPropertyEffects.Add(new PropertyMarkEffect
@@ -489,21 +510,30 @@ public class PathMarkSyncService : ScopedService
             effectiveEffects.AddRange(oldEffects);
         }
 
-        // Group effects by (ResourceId, PropertyPool, PropertyId)
-        var groupedEffects = effectiveEffects
-            .GroupBy(e => (e.ResourceId, e.PropertyPool, e.PropertyId))
-            .ToList();
-
         // Pre-load custom property definitions for type lookup
-        var customPropertyIds = groupedEffects
-            .Where(g => g.Key.PropertyPool == PropertyPool.Custom)
-            .Select(g => g.Key.PropertyId)
+        var customPropertyIds = effectiveEffects
+            .Where(e => e.PropertyPool == PropertyPool.Custom)
+            .Select(e => e.PropertyId)
             .Distinct()
             .ToList();
 
         var customProperties = customPropertyIds.Count > 0
             ? (await _customPropertyService.GetByKeys(customPropertyIds)).ToDictionary(p => p.Id)
             : new Dictionary<int, CustomProperty>();
+
+        // Property-mark effects have one canonical contract: Value is serialized with
+        // the property's BizValueType. V220 seeded effects by copying CustomPropertyValue.Value,
+        // so those rows contain serialized DB ids instead. Normalize persisted reference
+        // effects lazily before combining them. Only deterministic re-extraction from
+        // the mark/config/resource can prove what the business value was; if that is
+        // unavailable, preserve the existing property value instead of guessing.
+        NormalizePersistedReferenceEffects(effectiveEffects, customProperties, ctx);
+
+        // Group effects by (ResourceId, PropertyPool, PropertyId) after normalization;
+        // unresolved legacy references are excluded rather than auto-created as labels.
+        var groupedEffects = effectiveEffects
+            .GroupBy(e => (e.ResourceId, e.PropertyPool, e.PropertyId))
+            .ToList();
 
         // Pre-load existing property values for comparison. Include resources that previously
         // had effects from run marks too so we can correctly upsert / leave-alone.
@@ -528,6 +558,12 @@ public class PathMarkSyncService : ScopedService
             // Skip Internal pool (handled separately for media library)
             if (pool == PropertyPool.Internal) continue;
 
+            // An unresolved legacy id means this group's current combined DB value is
+            // the only lossless representation left. Do not overwrite it from an
+            // incomplete subset of effects; a full re-sync of that mark will replace
+            // the ambiguous row with a freshly extracted business value.
+            if (ctx.PropertyValueKeysToPreserve.Contains(group.Key)) continue;
+
             // Order by priority (descending) - for single-value properties, first wins
             var effects = group.OrderByDescending(e => e.Priority).ThenByDescending(e => e.MarkId).ToList();
             if (effects.Count == 0) continue;
@@ -545,11 +581,7 @@ public class PathMarkSyncService : ScopedService
             // A mark always yields human-readable text (a directory name, a regex capture),
             // never an option id. For reference types (choice / tags / multilevel) that text
             // is a biz value: combine it as one, then convert it into the db value so the
-            // option is created on the property. Skipping that step leaves the property with
-            // no options at all, so the resource filter has nothing to offer — while the
-            // resource itself still reads fine, because Resource.Property.PropertyValue
-            // falls back to the raw db value once the descriptor returns a null biz value.
-            // That fallback is what makes this failure look like a filter-only problem.
+            // option is created on the property.
             string? combinedValue;
             if (pool == PropertyPool.Custom &&
                 PropertySystem.Property.IsReferenceValueType(propertyType.Value) &&
@@ -597,7 +629,8 @@ public class PathMarkSyncService : ScopedService
             {
                 if (effect.PropertyPool == PropertyPool.Internal) continue;
                 var key = (effect.ResourceId, effect.PropertyPool, effect.PropertyId);
-                if (!ctx.FinalPropertyValues.ContainsKey(key))
+                if (!ctx.FinalPropertyValues.ContainsKey(key) &&
+                    !ctx.PropertyValueKeysToPreserve.Contains(key))
                 {
                     ctx.PropertyValuesToDelete.Add((effect.ResourceId, effect.PropertyId));
                 }
@@ -637,6 +670,143 @@ public class PathMarkSyncService : ScopedService
 
         return dbValue?.SerializeAsStandardValue(PropertySystem.Property.GetDbValueType(customProperty.Type));
     }
+
+    /// <summary>
+    /// Converts V220's persisted DB-valued reference effects to the canonical serialized
+    /// business value. Only persisted effects are considered; freshly collected effects
+    /// already contain business values.
+    ///
+    /// The current mark configuration and resource path are the strongest source of truth,
+    /// so they are used first to re-extract the business value. This makes the repair
+    /// deterministic even for a legitimate UUID label or an old id whose option was deleted.
+    /// If re-extraction is impossible, the representation is ambiguous: reference DB and
+    /// business values can have the same lexical shape, so even a DB -> Biz -> DB round-trip
+    /// is not independent proof. Such an effect is omitted and its combined property value
+    /// is preserved until the mark can be fully re-collected.
+    /// </summary>
+    private void NormalizePersistedReferenceEffects(
+        List<PropertyMarkEffect> effectiveEffects,
+        IReadOnlyDictionary<int, CustomProperty> customProperties,
+        SyncContext ctx)
+    {
+        var unresolvedEffectIds = new HashSet<int>();
+        var unresolvedCounts = new Dictionary<(int MarkId, int PropertyId), int>();
+
+        foreach (var effect in effectiveEffects.Where(e => e.Id > 0 && e.PropertyPool == PropertyPool.Custom))
+        {
+            if (!customProperties.TryGetValue(effect.PropertyId, out var customProperty) ||
+                !PropertySystem.Property.IsReferenceValueType(customProperty.Type) ||
+                string.IsNullOrEmpty(effect.Value))
+            {
+                continue;
+            }
+
+            // This is the same applicability/extraction path used by CollectPropertyEffects.
+            // If it succeeds there is no representation guess: persist exactly what a fresh
+            // collection would have produced.
+            if (TryExtractCurrentBusinessValue(effect, ctx, out var extractedBizValue))
+            {
+                if (effect.Value != extractedBizValue)
+                {
+                    effect.Value = extractedBizValue;
+                    ctx.PropertyEffectsToUpdate[effect.Id] = effect;
+                }
+
+                continue;
+            }
+
+            // Never feed an unverified persisted reference value into AutoCreateOptions:
+            // it may be a dangling legacy DB id, while a value that happens to match an
+            // option id may instead be a perfectly legitimate business label.
+            unresolvedEffectIds.Add(effect.Id);
+            ctx.PropertyValueKeysToPreserve.Add(
+                (effect.ResourceId, effect.PropertyPool, effect.PropertyId));
+            var warningKey = (effect.MarkId, effect.PropertyId);
+            unresolvedCounts[warningKey] = unresolvedCounts.GetValueOrDefault(warningKey) + 1;
+        }
+
+        foreach (var ((markId, propertyId), count) in unresolvedCounts)
+        {
+            _logger.LogWarning(
+                "[Sync] Skipped {Count} unresolved legacy reference effects from mark {MarkId} for custom " +
+                "property {PropertyId}; a full mark re-sync is required to recover their business labels",
+                count, markId, propertyId);
+        }
+
+        if (unresolvedEffectIds.Count > 0)
+        {
+            effectiveEffects.RemoveAll(e => unresolvedEffectIds.Contains(e.Id));
+        }
+    }
+
+    /// <summary>
+    /// Rebuilds the effect through the same resource applicability and value extraction
+    /// rules as <see cref="CollectPropertyEffects"/>. Returning false means the current
+    /// mark/resource cannot prove what the persisted representation is.
+    /// </summary>
+    private bool TryExtractCurrentBusinessValue(
+        PropertyMarkEffect effect,
+        SyncContext ctx,
+        out string businessValue)
+    {
+        businessValue = null!;
+
+        if (!ctx.PathMarksById.TryGetValue(effect.MarkId, out var mark) ||
+            mark.Type != PathMarkType.Property ||
+            !ctx.IdToResource.TryGetValue(effect.ResourceId, out var resource) ||
+            string.IsNullOrEmpty(resource.Path))
+        {
+            return false;
+        }
+
+        if (!ctx.PropertyMarkConfigsByMarkId.TryGetValue(mark.Id, out var config) ||
+            config == null || config.Pool != effect.PropertyPool || config.PropertyId != effect.PropertyId)
+        {
+            return false;
+        }
+
+        try
+        {
+            if (!ctx.IsPathUnderParent(resource.Path, mark.Path) ||
+                !FilterResourcesByMarkConfig([resource], mark.Path, config, ctx)
+                    .Any(r => r.Id == resource.Id))
+            {
+                return false;
+            }
+
+            object? extractedValue;
+            if (config.ValueType == PropertyValueType.Fixed)
+            {
+                extractedValue = config.FixedValue;
+            }
+            else
+            {
+                var resourcePath = config.ValueLayer is > 0 ? resource.Path : null;
+                extractedValue = ExtractDynamicValue(mark.Path, resourcePath, config.MatchMode,
+                    config.ValueLayer, config.ValueRegex, ctx);
+            }
+
+            if (extractedValue == null)
+            {
+                return false;
+            }
+
+            businessValue = SerializePropertyMarkEffectValue(extractedValue);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            // Historical context must never turn a malformed/stale mark config into
+            // a failure of an otherwise unrelated partial sync.
+            _logger.LogDebug(ex,
+                "[Sync] Could not re-extract business value for legacy effect {EffectId}", effect.Id);
+            return false;
+        }
+    }
+
+    private static string SerializePropertyMarkEffectValue(object value) => value is string s
+        ? s
+        : System.Text.Json.JsonSerializer.Serialize(value, System.Text.Json.JsonSerializerOptions.Web);
 
     /// <summary>
     /// Computes final media library mappings from effective effects.
@@ -849,16 +1019,19 @@ public class PathMarkSyncService : ScopedService
     #region Phase 4: Persist Effects
 
     /// <summary>
-    /// Computes which effects to add and delete by comparing collected vs old.
+    /// Computes which effects to add, update and delete by comparing collected vs old.
     /// </summary>
     private Task ComputeEffectDiff(SyncContext ctx)
     {
-        // Property effects to add: in collected but not already known for the same key.
-        // Effect records for context marks are NEVER touched here (they belong to
-        // marks that weren't synced this run).
-        var runOldKeys = ctx.RunOldEffectsByMarkId
-            .SelectMany(kvp => kvp.Value.Select(e => (e.MarkId, e.PropertyPool, e.PropertyId, e.ResourceId)))
-            .ToHashSet();
+        // Collected effects either insert a new key or refresh the existing row's value
+        // and priority. Reusing the old row preserves its id/CreatedAt and avoids the
+        // unique-key race of delete-then-add. Context rows are touched only when Phase 2
+        // already queued a legacy representation normalization.
+        var runOldByKey = ctx.RunOldEffectsByMarkId
+            .SelectMany(kvp => kvp.Value)
+            .ToDictionary(
+                e => (e.MarkId, e.PropertyPool, e.PropertyId, e.ResourceId),
+                e => e);
 
         var addedPropertyKeys =
             new HashSet<(int MarkId, PropertyPool Pool, int PropertyId, int ResourceId)>();
@@ -866,7 +1039,21 @@ public class PathMarkSyncService : ScopedService
         foreach (var effect in ctx.CollectedPropertyEffects)
         {
             var key = (effect.MarkId, effect.PropertyPool, effect.PropertyId, effect.ResourceId);
-            if (!runOldKeys.Contains(key) && addedPropertyKeys.Add(key))
+            if (!addedPropertyKeys.Add(key))
+            {
+                continue;
+            }
+
+            if (runOldByKey.TryGetValue(key, out var oldEffect))
+            {
+                if (oldEffect.Value != effect.Value || oldEffect.Priority != effect.Priority)
+                {
+                    oldEffect.Value = effect.Value;
+                    oldEffect.Priority = effect.Priority;
+                    ctx.PropertyEffectsToUpdate[oldEffect.Id] = oldEffect;
+                }
+            }
+            else
             {
                 ctx.PropertyEffectsToAdd.Add(effect);
             }
@@ -890,8 +1077,9 @@ public class PathMarkSyncService : ScopedService
         }
 
         _logger.LogInformation(
-            "[Sync] Effect diff: PropertyEffects +{AddProp}/-{DelProp}",
-            ctx.PropertyEffectsToAdd.Count, ctx.PropertyEffectIdsToDelete.Count);
+            "[Sync] Effect diff: PropertyEffects +{AddProp}/~{UpdateProp}/-{DelProp}",
+            ctx.PropertyEffectsToAdd.Count, ctx.PropertyEffectsToUpdate.Count,
+            ctx.PropertyEffectIdsToDelete.Count);
 
         return Task.CompletedTask;
     }
@@ -910,6 +1098,17 @@ public class PathMarkSyncService : ScopedService
             for (var i = 0; i < batches.Count; i++)
             {
                 await _effectService.AddPropertyEffects(batches[i]);
+                if (i < batches.Count - 1) await Task.Delay(5);
+            }
+        }
+
+        // Update same-key effects and lazily normalized V220 effects.
+        if (ctx.PropertyEffectsToUpdate.Count > 0)
+        {
+            var batches = ctx.PropertyEffectsToUpdate.Values.Chunk(BatchSize).ToList();
+            for (var i = 0; i < batches.Count; i++)
+            {
+                await _effectService.UpdatePropertyEffects(batches[i]);
                 if (i < batches.Count - 1) await Task.Delay(5);
             }
         }

--- a/src/legacy/Bakabase.InsideWorld.Business/Services/SyncContext.cs
+++ b/src/legacy/Bakabase.InsideWorld.Business/Services/SyncContext.cs
@@ -22,6 +22,8 @@ internal class SyncContext
     public Dictionary<string, Resource> PathToResource { get; } = new(StringComparer.OrdinalIgnoreCase);
     public HashSet<string> ExistingPathSet { get; } = new(StringComparer.OrdinalIgnoreCase);
     public Dictionary<int, Resource> IdToResource { get; } = new();
+    public Dictionary<int, PathMark> PathMarksById { get; } = new();
+    public Dictionary<int, PropertyMarkConfig?> PropertyMarkConfigsByMarkId { get; } = new();
 
     // Caches for standardized paths
     public Dictionary<string, string> StandardizedPaths { get; } = new(StringComparer.OrdinalIgnoreCase);
@@ -53,7 +55,9 @@ internal class SyncContext
 
     // Old effects of already-synced marks loaded purely for context — used to
     // recompute combined property values and to protect media library mappings
-    // contributed by other marks. NEVER deleted, never re-keyed.
+    // contributed by other marks. They are never deleted or re-keyed by this run,
+    // but a legacy DB-valued reference effect may be normalized in place to the
+    // canonical serialized business value.
     public Dictionary<int, List<PropertyMarkEffect>> ContextOldEffectsByMarkId { get; } = new();
 
     // ===== Phase 2: Compute Final State =====
@@ -61,6 +65,11 @@ internal class SyncContext
     // Key: (ResourceId, PropertyPool, PropertyId), Value: serialized combined value
     public Dictionary<(int ResourceId, PropertyPool Pool, int PropertyId), string?> FinalPropertyValues { get; } =
         new();
+
+    // A persisted reference effect that cannot be re-extracted or decoded safely may
+    // be a legacy DB value. Preserve the current combined property value for the key
+    // until that mark is fully re-collected rather than recomputing from partial data.
+    public HashSet<(int ResourceId, PropertyPool Pool, int PropertyId)> PropertyValueKeysToPreserve { get; } = new();
 
     // Final computed media library mappings
     // Key: ResourceId, Value: list of MediaLibraryIds
@@ -86,6 +95,7 @@ internal class SyncContext
 
     // ===== Phase 4: Persist Effects =====
     public List<PropertyMarkEffect> PropertyEffectsToAdd { get; } = new();
+    public Dictionary<int, PropertyMarkEffect> PropertyEffectsToUpdate { get; } = new();
     public List<int> PropertyEffectIdsToDelete { get; } = new();
 
     // ===== Tracking =====

--- a/src/legacy/Bakabase.Migrations/V220/V220Migrator.cs
+++ b/src/legacy/Bakabase.Migrations/V220/V220Migrator.cs
@@ -9,7 +9,11 @@ using Bakabase.InsideWorld.Business.Components.Configurations;
 using Bakabase.InsideWorld.Business.Components.Configurations.Models.Domain;
 using Bakabase.InsideWorld.Models.Constants;
 using Bakabase.Modules.Property;
+using Bakabase.Modules.Property.Abstractions.Components;
+using Bakabase.Modules.Property.Extensions;
 using Bakabase.Modules.Search.Models.Db;
+using Bakabase.Modules.StandardValue;
+using Bakabase.Modules.StandardValue.Extensions;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
@@ -761,6 +765,26 @@ public class V220Migrator : AbstractMigrator
             .GroupBy(m => m.ResourceId)
             .ToDictionary(g => g.Key, g => g.Select(m => m.MediaLibraryId).ToHashSet());
 
+        // PropertyMarkEffect.Value uses the property's serialized BizValueType. The
+        // source CustomPropertyValue rows below contain serialized DB values, so load
+        // definitions/options once and cross that boundary explicitly while seeding.
+        var customProperties = new Dictionary<int, CustomProperty>();
+        foreach (var dbProperty in await dbCtx.CustomProperties.AsNoTracking().ToListAsync())
+        {
+            try
+            {
+                customProperties[dbProperty.Id] = dbProperty.ToDomainModel();
+            }
+            catch (Exception ex)
+            {
+                // One malformed legacy options payload must not strand the entire V220
+                // migration after its PathMarks have already been inserted.
+                Logger.LogWarning(ex,
+                    "Could not load custom property {PropertyId} while creating PathMark effects; skipping it.",
+                    dbProperty.Id);
+            }
+        }
+
         var resourceMarkEffects = new List<ResourceMarkEffectDbModel>();
         var propertyMarkEffects = new List<PropertyMarkEffectDbModel>();
 
@@ -840,6 +864,7 @@ public class V220Migrator : AbstractMigrator
 
                     // Only handle Custom properties for now
                     if (config.Pool != PropertyPool.Custom) continue;
+                    if (!customProperties.TryGetValue(config.PropertyId, out var customProperty)) continue;
 
                     // Get existing property values for these resources
                     var resourceIds = resourcesUnderPath.Select(r => r.Id).ToList();
@@ -858,13 +883,27 @@ public class V220Migrator : AbstractMigrator
                     {
                         if (pvByResourceId.TryGetValue(resource.Id, out var pv) && !string.IsNullOrEmpty(pv.Value))
                         {
+                            if (!TryConvertDbValueToCanonicalEffectValue(customProperty, pv.Value,
+                                    out var effectValue))
+                            {
+                                // A malformed value or dangling reference cannot be converted
+                                // losslessly. Keep the existing property value, but do not seed
+                                // a mixed/ambiguous effect that a later sync could turn into a
+                                // UUID-labelled option.
+                                Logger.LogWarning(
+                                    "Could not convert property value of resource {ResourceId}, property {PropertyId} " +
+                                    "to a business value while creating PathMark effects; the effect was skipped.",
+                                    resource.Id, config.PropertyId);
+                                continue;
+                            }
+
                             propertyMarkEffects.Add(new PropertyMarkEffectDbModel
                             {
                                 MarkId = pathMark.Id,
                                 PropertyPool = (int)config.Pool,
                                 PropertyId = config.PropertyId,
                                 ResourceId = resource.Id,
-                                Value = pv.Value,
+                                Value = effectValue,
                                 Priority = pathMark.Priority,
                                 CreatedAt = now,
                                 UpdatedAt = now
@@ -889,6 +928,36 @@ public class V220Migrator : AbstractMigrator
             await dbCtx.PropertyMarkEffects.AddRangeAsync(propertyMarkEffects);
             await dbCtx.SaveChangesAsync();
             Logger.LogInformation("Created {Count} PropertyMarkEffects from PathMarks.", propertyMarkEffects.Count);
+        }
+    }
+
+    private static bool TryConvertDbValueToCanonicalEffectValue(
+        CustomProperty customProperty,
+        string serializedDbValue,
+        out string? serializedBizValue)
+    {
+        serializedBizValue = null;
+        try
+        {
+            var property = customProperty.ToProperty();
+            var dbValueType = PropertySystem.Property.GetDbValueType(customProperty.Type);
+            var dbValue = serializedDbValue.DeserializeAsStandardValue(dbValueType);
+            var bizValue = PropertySystem.Property.ToBizValue(property, dbValue);
+            if (dbValue == null || bizValue == null) return false;
+
+            // GetBizValue can drop dangling entries for collection reference types. Only
+            // seed the effect when no information was lost in the conversion.
+            var (roundTrippedDbValue, _) = PropertySystem.Property.ToDbValue(
+                property, bizValue, PropertyValueMatchPolicy.MatchOnly);
+            if (!StandardValueSystem.GetHandler(dbValueType).Compare(dbValue, roundTrippedDbValue)) return false;
+
+            serializedBizValue = bizValue.SerializeAsStandardValue(
+                PropertySystem.Property.GetBizValueType(customProperty.Type));
+            return !string.IsNullOrEmpty(serializedBizValue);
+        }
+        catch
+        {
+            return false;
         }
     }
 

--- a/src/tests/Bakabase.Tests/PathMarkReferenceValueRegressionTests.cs
+++ b/src/tests/Bakabase.Tests/PathMarkReferenceValueRegressionTests.cs
@@ -1,0 +1,580 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Bakabase.Abstractions.Components.Tasks;
+using Bakabase.Abstractions.Models.Domain;
+using Bakabase.Abstractions.Models.Domain.Constants;
+using Bakabase.Abstractions.Models.Dto;
+using Bakabase.Abstractions.Models.Input;
+using Bakabase.Abstractions.Services;
+using Bakabase.InsideWorld.Business.Services;
+using Bakabase.InsideWorld.Models.Constants.AdditionalItems;
+using Bakabase.Modules.Property;
+using Bakabase.Modules.Property.Abstractions.Models.Db;
+using Bakabase.Modules.Property.Abstractions.Services;
+using Bakabase.Modules.Property.Components.Properties.Choice;
+using Bakabase.Modules.Property.Components.Properties.Choice.Abstractions;
+using Bakabase.Modules.Property.Components.Properties.Multilevel;
+using Bakabase.Modules.Property.Components.Properties.Tags;
+using Bakabase.Modules.Property.Extensions;
+using Bakabase.Modules.StandardValue.Extensions;
+using Bakabase.TestKit.Utils;
+using Bootstrap.Components.Tasks;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json;
+
+namespace Bakabase.Tests;
+
+/// <summary>
+/// Regression coverage for the canonical business-value representation of
+/// <see cref="PropertyMarkEffect.Value"/> and the legacy V220 rows that were incorrectly
+/// seeded with serialized database values. A partial sync must not reinterpret an old option
+/// id as a label and create a second reference whose label is that id.
+/// </summary>
+[TestClass]
+public sealed class PathMarkReferenceValueRegressionTests
+{
+    private string _testRoot = null!;
+    private IServiceProvider _sp = null!;
+
+    [TestInitialize]
+    public async Task Setup()
+    {
+        _sp = await TestServiceBuilder.BuildServiceProvider();
+        _testRoot = Path.Combine(
+            Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)!,
+            $"PathMarkReferenceValueRegressionTests.{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_testRoot);
+    }
+
+    [TestCleanup]
+    public void Cleanup()
+    {
+        if (Directory.Exists(_testRoot))
+        {
+            try
+            {
+                Directory.Delete(_testRoot, true);
+            }
+            catch
+            {
+                // Best-effort cleanup. A failed assertion should remain the test's failure.
+            }
+        }
+    }
+
+    [TestMethod]
+    public async Task PartialSync_V220ReferenceEffectsCanonicalizeWithoutChangingDbValues_AndFiltersMatch()
+    {
+        var resourceService = _sp.GetRequiredService<IResourceService>();
+        var propertyService = _sp.GetRequiredService<ICustomPropertyService>();
+        var propertyValueService = _sp.GetRequiredService<ICustomPropertyValueService>();
+        var pathMarkService = _sp.GetRequiredService<IPathMarkService>();
+        var effectService = _sp.GetRequiredService<IPathMarkEffectService>();
+
+        // The reported production case extracts the value from a directory layer.
+        // Keep that exact path in the single-choice case; the other reference types share
+        // the same resource while exercising their distinct standard-value shapes.
+        var resourcePath = Path.Combine(_testRoot, "Action");
+        Directory.CreateDirectory(resourcePath);
+        await resourceService.AddOrPutRange([
+            new Resource
+            {
+                Path = resourcePath,
+                IsFile = false
+            }
+        ]);
+        var resource = (await resourceService.GetAll()).Should().ContainSingle().Subject;
+
+        var singleChoiceId = Guid.NewGuid().ToString();
+        var multipleChoiceId = Guid.NewGuid().ToString();
+        var tagId = Guid.NewGuid().ToString();
+        var multilevelRootId = Guid.NewGuid().ToString();
+        var multilevelLeafId = Guid.NewGuid().ToString();
+
+        var singleChoice = await AddProperty(
+            "Legacy single choice",
+            PropertyType.SingleChoice,
+            new SingleChoicePropertyOptions
+            {
+                Choices = [new ChoiceOptions {Label = "Action", Value = singleChoiceId}]
+            });
+        var multipleChoice = await AddProperty(
+            "Legacy multiple choice",
+            PropertyType.MultipleChoice,
+            new MultipleChoicePropertyOptions
+            {
+                Choices = [new ChoiceOptions {Label = "Comedy", Value = multipleChoiceId}]
+            });
+        var tags = await AddProperty(
+            "Legacy tags",
+            PropertyType.Tags,
+            new TagsPropertyOptions
+            {
+                Tags = [new TagsPropertyOptions.TagOptions("Genre", "Drama") {Value = tagId}]
+            });
+        var multilevel = await AddProperty(
+            "Legacy multilevel",
+            PropertyType.Multilevel,
+            new MultilevelPropertyOptions
+            {
+                Data =
+                [
+                    new MultilevelDataOptions
+                    {
+                        Label = "Region",
+                        Value = multilevelRootId,
+                        Children =
+                        [
+                            new MultilevelDataOptions
+                            {
+                                Label = "Japan",
+                                Value = multilevelLeafId
+                            }
+                        ]
+                    }
+                ]
+            });
+
+        var legacyCases = new[]
+        {
+            (Property: singleChoice, SerializedDbValue: singleChoiceId, CanonicalEffectValue: "Action"),
+            (Property: multipleChoice, SerializedDbValue: multipleChoiceId, CanonicalEffectValue: "Comedy"),
+            (Property: tags, SerializedDbValue: tagId, CanonicalEffectValue: "Genre,Drama"),
+            (Property: multilevel, SerializedDbValue: multilevelLeafId, CanonicalEffectValue: "Region,Japan")
+        };
+        var contextMarkIds = new Dictionary<int, int>();
+
+        foreach (var (property, serializedDbValue, canonicalEffectValue) in legacyCases)
+        {
+            // V220 created a Synced mark plus an effect copied verbatim from
+            // CustomPropertyValues.Value.  It did not collect the path label again.
+            var contextMark = property.Id == singleChoice.Id
+                ? await AddLayerPropertyMark(property.Id)
+                : await AddPropertyMark(property.Id, canonicalEffectValue);
+            await pathMarkService.MarkAsSynced(contextMark.Id);
+            contextMarkIds[property.Id] = contextMark.Id;
+
+            await propertyValueService.AddDbModelRange([
+                new CustomPropertyValueDbModel
+                {
+                    ResourceId = resource.Id,
+                    PropertyId = property.Id,
+                    Scope = (int) PropertyValueScope.Synchronization,
+                    Value = serializedDbValue
+                }
+            ]);
+            await effectService.AddPropertyEffects([
+                new PropertyMarkEffect
+                {
+                    MarkId = contextMark.Id,
+                    PropertyPool = PropertyPool.Custom,
+                    PropertyId = property.Id,
+                    ResourceId = resource.Id,
+                    Value = serializedDbValue,
+                    Priority = contextMark.Priority
+                }
+            ]);
+        }
+
+        // Sync an unrelated mark. The four migrated marks stay Synced and therefore enter
+        // the run only through ContextOldEffectsByMarkId -- the beta.144 corruption path.
+        var triggerProperty = await AddProperty("Partial-sync trigger", PropertyType.SingleLineText);
+        await AddPropertyMark(triggerProperty.Id, "touch");
+        await SyncPendingPropertyMarks();
+
+        var refreshedSingleChoice = await propertyService.GetByKey(singleChoice.Id);
+        var refreshedMultipleChoice = await propertyService.GetByKey(multipleChoice.Id);
+        var refreshedTags = await propertyService.GetByKey(tags.Id);
+        var refreshedMultilevel = await propertyService.GetByKey(multilevel.Id);
+
+        var singleOptions = refreshedSingleChoice.Options.Should()
+            .BeOfType<SingleChoicePropertyOptions>().Subject;
+        singleOptions.Choices.Should().ContainSingle()
+            .Which.Should().BeEquivalentTo(new ChoiceOptions {Label = "Action", Value = singleChoiceId});
+
+        var multipleOptions = refreshedMultipleChoice.Options.Should()
+            .BeOfType<MultipleChoicePropertyOptions>().Subject;
+        multipleOptions.Choices.Should().ContainSingle()
+            .Which.Should().BeEquivalentTo(new ChoiceOptions {Label = "Comedy", Value = multipleChoiceId});
+
+        var tagOptions = refreshedTags.Options.Should().BeOfType<TagsPropertyOptions>().Subject;
+        tagOptions.Tags.Should().ContainSingle(t =>
+            t.Group == "Genre" && t.Name == "Drama" && t.Value == tagId);
+
+        var multilevelOptions = refreshedMultilevel.Options.Should()
+            .BeOfType<MultilevelPropertyOptions>().Subject;
+        var multilevelRoot = multilevelOptions.Data.Should().ContainSingle().Subject;
+        multilevelRoot.Label.Should().Be("Region");
+        multilevelRoot.Value.Should().Be(multilevelRootId);
+        var multilevelLeaf = multilevelRoot.Children.Should().ContainSingle().Subject;
+        multilevelLeaf.Label.Should().Be("Japan");
+        multilevelLeaf.Value.Should().Be(multilevelLeafId);
+
+        foreach (var (property, serializedDbValue, canonicalEffectValue) in legacyCases)
+        {
+            var stored = (await propertyValueService.GetAllDbModels(v =>
+                    v.ResourceId == resource.Id && v.PropertyId == property.Id))
+                .Should().ContainSingle().Subject;
+            stored.Value.Should().Be(serializedDbValue,
+                "a V220 DB value must not be converted as if its UUID were a business label");
+
+            var normalizedEffect = (await effectService.GetPropertyEffectsByMarkId(contextMarkIds[property.Id]))
+                .Should().ContainSingle().Subject;
+            normalizedEffect.Value.Should().Be(canonicalEffectValue,
+                "legacy DB-valued effects should be rewritten to the canonical serialized business value");
+        }
+
+        // Filtering operates on DB ids. This catches the user-visible half of the regression:
+        // every original human-labelled option must still select the id stored on the resource.
+        await RebuildSearchIndex();
+        await AssertReferenceSearchMatches(resource.Id, refreshedSingleChoice,
+            SearchOperation.Equals, singleChoiceId);
+        await AssertReferenceSearchMatches(resource.Id, refreshedMultipleChoice,
+            SearchOperation.Contains, new List<string> {multipleChoiceId});
+        await AssertReferenceSearchMatches(resource.Id, refreshedTags,
+            SearchOperation.Contains, new List<string> {tagId});
+        await AssertReferenceSearchMatches(resource.Id, refreshedMultilevel,
+            SearchOperation.Contains, new List<string> {multilevelLeafId});
+    }
+
+    [TestMethod]
+    public async Task PartialSync_Beta144PollutedSingleChoice_RepairsValueAndSearchWithoutDeletingChoices()
+    {
+        var resourceService = _sp.GetRequiredService<IResourceService>();
+        var propertyService = _sp.GetRequiredService<ICustomPropertyService>();
+        var propertyValueService = _sp.GetRequiredService<ICustomPropertyValueService>();
+        var pathMarkService = _sp.GetRequiredService<IPathMarkService>();
+        var effectService = _sp.GetRequiredService<IPathMarkEffectService>();
+
+        var resourcePath = Path.Combine(_testRoot, "Movie");
+        Directory.CreateDirectory(resourcePath);
+        await resourceService.AddOrPutRange([new Resource {Path = resourcePath, IsFile = false}]);
+        var resource = (await resourceService.GetAll()).Should().ContainSingle().Subject;
+
+        // beta.144 interpreted the V220 effect's old DB id (U0) as a business label,
+        // creating U1 and moving the synchronized property value to it.
+        var originalChoiceId = Guid.NewGuid().ToString();
+        var pollutedChoiceId = Guid.NewGuid().ToString();
+        var property = await AddProperty(
+            "Polluted single choice",
+            PropertyType.SingleChoice,
+            new SingleChoicePropertyOptions
+            {
+                Choices =
+                [
+                    new ChoiceOptions {Label = "Action", Value = originalChoiceId},
+                    new ChoiceOptions {Label = originalChoiceId, Value = pollutedChoiceId}
+                ]
+            });
+
+        var contextMark = await AddPropertyMark(property.Id, "Action");
+        await pathMarkService.MarkAsSynced(contextMark.Id);
+        await propertyValueService.AddDbModelRange([
+            new CustomPropertyValueDbModel
+            {
+                ResourceId = resource.Id,
+                PropertyId = property.Id,
+                Scope = (int) PropertyValueScope.Synchronization,
+                Value = pollutedChoiceId
+            }
+        ]);
+        await effectService.AddPropertyEffects([
+            new PropertyMarkEffect
+            {
+                MarkId = contextMark.Id,
+                PropertyPool = PropertyPool.Custom,
+                PropertyId = property.Id,
+                ResourceId = resource.Id,
+                Value = originalChoiceId,
+                Priority = contextMark.Priority
+            }
+        ]);
+
+        var triggerProperty = await AddProperty("Partial-sync trigger", PropertyType.SingleLineText);
+        await AddPropertyMark(triggerProperty.Id, "touch");
+        await SyncPendingPropertyMarks();
+
+        var refreshedProperty = await propertyService.GetByKey(property.Id);
+        var refreshedOptions = refreshedProperty.Options.Should()
+            .BeOfType<SingleChoicePropertyOptions>().Subject;
+        refreshedOptions.Choices.Should().HaveCount(2,
+            "path-mark sync cannot safely delete an orphan option that may have been user-created");
+        refreshedOptions.Choices.Should().Contain(c =>
+            c.Label == "Action" && c.Value == originalChoiceId);
+        refreshedOptions.Choices.Should().Contain(c =>
+            c.Label == originalChoiceId && c.Value == pollutedChoiceId);
+
+        var stored = (await propertyValueService.GetAllDbModels(v =>
+                v.ResourceId == resource.Id && v.PropertyId == property.Id))
+            .Should().ContainSingle().Subject;
+        stored.Value.Should().Be(originalChoiceId,
+            "the polluted U1 reference must be repaired to the original human-labelled option U0");
+
+        var normalizedEffect = (await effectService.GetPropertyEffectsByMarkId(contextMark.Id))
+            .Should().ContainSingle().Subject;
+        normalizedEffect.Value.Should().Be("Action",
+            "the V220 DB-valued effect should be persisted in canonical business-value form");
+
+        var reloadedResource = await resourceService.Get(resource.Id, ResourceAdditionalItem.Properties);
+        var reloadedValue = reloadedResource!.Properties![(int) PropertyPool.Custom][property.Id]
+            .Values!.Should().ContainSingle(v => v.Scope == (int) PropertyValueScope.Synchronization).Subject;
+        reloadedValue.Value.Should().Be(originalChoiceId);
+        reloadedValue.BizValue.Should().Be("Action");
+
+        await RebuildSearchIndex();
+        await AssertReferenceSearchMatches(resource.Id, refreshedProperty,
+            SearchOperation.Equals, originalChoiceId);
+    }
+
+    [TestMethod]
+    public async Task Resync_SameEffectKey_UpdatesThePersistedEffectValue()
+    {
+        var resourceService = _sp.GetRequiredService<IResourceService>();
+        var propertyService = _sp.GetRequiredService<ICustomPropertyService>();
+        var propertyValueService = _sp.GetRequiredService<ICustomPropertyValueService>();
+        var pathMarkService = _sp.GetRequiredService<IPathMarkService>();
+        var effectService = _sp.GetRequiredService<IPathMarkEffectService>();
+
+        var resourcePath = Path.Combine(_testRoot, "Movie");
+        Directory.CreateDirectory(resourcePath);
+        await resourceService.AddOrPutRange([new Resource {Path = resourcePath, IsFile = false}]);
+        var resource = (await resourceService.GetAll()).Should().ContainSingle().Subject;
+
+        var property = await AddProperty("Mutable mark value", PropertyType.SingleChoice);
+        var mark = await AddPropertyMark(property.Id, "Before");
+
+        await SyncPendingPropertyMarks();
+
+        var initialEffect = (await effectService.GetPropertyEffectsByMarkId(mark.Id))
+            .Should().ContainSingle().Subject;
+        initialEffect.Value.Should().Be("Before");
+
+        var markToUpdate = (await pathMarkService.GetAll()).Single(m => m.Id == mark.Id);
+        markToUpdate.ConfigJson = BuildPropertyMarkConfig(property.Id, "After");
+        markToUpdate.Priority = 75;
+        await pathMarkService.Update(markToUpdate);
+
+        await SyncPendingPropertyMarks();
+
+        var updatedEffect = (await effectService.GetPropertyEffectsByMarkId(mark.Id))
+            .Should().ContainSingle("the same effect key must be updated, not left stale or duplicated")
+            .Subject;
+        updatedEffect.Value.Should().Be("After");
+        updatedEffect.Priority.Should().Be(75,
+            "priority is part of the effect data and must be refreshed together with its value");
+
+        var refreshedProperty = await propertyService.GetByKey(property.Id);
+        var options = refreshedProperty.Options.Should().BeOfType<SingleChoicePropertyOptions>().Subject;
+        var afterChoiceId = options.Choices.Should().ContainSingle(c => c.Label == "After").Which.Value;
+
+        var stored = (await propertyValueService.GetAllDbModels(v =>
+                v.ResourceId == resource.Id && v.PropertyId == property.Id))
+            .Should().ContainSingle().Subject;
+        stored.Value.Should().Be(afterChoiceId);
+
+        var typedDbValue = stored.Value!.DeserializeAsStandardValue(
+            PropertySystem.Property.GetDbValueType(PropertyType.SingleChoice));
+        PropertySystem.Property.ToBizValue(refreshedProperty.ToProperty(), typedDbValue)
+            .Should().Be("After");
+    }
+
+    [TestMethod]
+    public async Task PartialSync_GuidShapedBusinessLabel_RemainsALabel_WhenReExtractionWorksOrIsAmbiguous()
+    {
+        var resourceService = _sp.GetRequiredService<IResourceService>();
+        var propertyService = _sp.GetRequiredService<ICustomPropertyService>();
+        var propertyValueService = _sp.GetRequiredService<ICustomPropertyValueService>();
+        var pathMarkService = _sp.GetRequiredService<IPathMarkService>();
+        var effectService = _sp.GetRequiredService<IPathMarkEffectService>();
+
+        var resourcePath = Path.Combine(_testRoot, "Movie");
+        Directory.CreateDirectory(resourcePath);
+        await resourceService.AddOrPutRange([new Resource {Path = resourcePath, IsFile = false}]);
+        var resource = (await resourceService.GetAll()).Should().ContainSingle().Subject;
+
+        // A GUID is a perfectly valid user-facing label.  Legacy-value detection must not
+        // classify it as a DB reference merely because it has the same lexical shape.
+        var guidLabel = Guid.NewGuid().ToString();
+        var property = await AddProperty("GUID-shaped label", PropertyType.SingleChoice);
+        var mark = await AddPropertyMark(property.Id, guidLabel);
+
+        await SyncPendingPropertyMarks();
+
+        var initiallyRefreshedProperty = await propertyService.GetByKey(property.Id);
+        var initialOptions = initiallyRefreshedProperty.Options.Should()
+            .BeOfType<SingleChoicePropertyOptions>().Subject;
+        var choice = initialOptions.Choices.Should()
+            .ContainSingle(c => c.Label == guidLabel).Which;
+        choice.Value.Should().NotBe(guidLabel,
+            "the GUID-shaped text is the business label, not a caller-supplied DB id");
+
+        var initialEffect = (await effectService.GetPropertyEffectsByMarkId(mark.Id))
+            .Should().ContainSingle().Subject;
+        initialEffect.Value.Should().Be(guidLabel);
+
+        // The mark is now context-only.  An unrelated sync exercises the compatibility
+        // classifier without recollecting this fixed value as a pending mark.
+        var triggerProperty = await AddProperty("Partial-sync trigger", PropertyType.SingleLineText);
+        await AddPropertyMark(triggerProperty.Id, "touch");
+        await SyncPendingPropertyMarks();
+
+        var finallyRefreshedProperty = await propertyService.GetByKey(property.Id);
+        var finalOptions = finallyRefreshedProperty.Options.Should()
+            .BeOfType<SingleChoicePropertyOptions>().Subject;
+        finalOptions.Choices.Should().ContainSingle()
+            .Which.Should().BeEquivalentTo(choice);
+
+        var finalEffect = (await effectService.GetPropertyEffectsByMarkId(mark.Id))
+            .Should().ContainSingle().Subject;
+        finalEffect.Value.Should().Be(guidLabel);
+
+        var stored = (await propertyValueService.GetAllDbModels(v =>
+                v.ResourceId == resource.Id && v.PropertyId == property.Id))
+            .Should().ContainSingle().Subject;
+        stored.Value.Should().Be(choice.Value);
+
+        var reloadedResource = await resourceService.Get(resource.Id, ResourceAdditionalItem.Properties);
+        var reloadedValue = reloadedResource!.Properties![(int) PropertyPool.Custom][property.Id]
+            .Values!.Should().ContainSingle(v => v.Scope == (int) PropertyValueScope.Synchronization).Subject;
+        reloadedValue.BizValue.Should().Be(guidLabel);
+
+        // Now remove the independent path/config evidence and create the exact lexical
+        // ambiguity that a DB -> Biz -> DB round-trip cannot solve: the legitimate label
+        // is also another choice's id. A later partial sync must preserve, not guess.
+        var ambiguousProperty = await propertyService.GetByKey(property.Id);
+        var ambiguousOptions = ambiguousProperty.Options.Should()
+            .BeOfType<SingleChoicePropertyOptions>().Subject;
+        ambiguousOptions.Choices!.Add(new ChoiceOptions {Label = "Decoy", Value = guidLabel});
+        await propertyService.Put(ambiguousProperty);
+
+        var ambiguousMark = (await pathMarkService.Get(mark.Id))!;
+        ambiguousMark.ConfigJson = "{";
+        await pathMarkService.Update(ambiguousMark);
+        await pathMarkService.MarkAsSynced(mark.Id);
+
+        var secondTriggerProperty = await AddProperty("Second partial-sync trigger", PropertyType.SingleLineText);
+        await AddPropertyMark(secondTriggerProperty.Id, "touch again");
+        await SyncPendingPropertyMarks();
+
+        var preservedEffect = (await effectService.GetPropertyEffectsByMarkId(mark.Id))
+            .Should().ContainSingle().Subject;
+        preservedEffect.Value.Should().Be(guidLabel);
+
+        var preservedValue = (await propertyValueService.GetAllDbModels(v =>
+                v.ResourceId == resource.Id && v.PropertyId == property.Id))
+            .Should().ContainSingle().Subject;
+        preservedValue.Value.Should().Be(choice.Value,
+            "an ambiguous business label must not be reinterpreted as the decoy choice id");
+
+        var preservedResource = await resourceService.Get(resource.Id, ResourceAdditionalItem.Properties);
+        var preservedResourceValue = preservedResource!.Properties![(int) PropertyPool.Custom][property.Id]
+            .Values!.Should().ContainSingle(v => v.Scope == (int) PropertyValueScope.Synchronization).Subject;
+        preservedResourceValue.BizValue.Should().Be(guidLabel);
+    }
+
+    private async Task<CustomProperty> AddProperty(string name, PropertyType type, object? options = null)
+    {
+        return await _sp.GetRequiredService<ICustomPropertyService>().Add(new CustomPropertyAddOrPutDto
+        {
+            Name = name,
+            Type = type,
+            Options = options == null ? null : JsonConvert.SerializeObject(options)
+        });
+    }
+
+    private async Task<PathMark> AddPropertyMark(int propertyId, string fixedValue)
+    {
+        return await _sp.GetRequiredService<IPathMarkService>().Add(new PathMark
+        {
+            Path = _testRoot,
+            Type = PathMarkType.Property,
+            ConfigJson = BuildPropertyMarkConfig(propertyId, fixedValue),
+            Priority = 50
+        });
+    }
+
+    private async Task<PathMark> AddLayerPropertyMark(int propertyId)
+    {
+        return await _sp.GetRequiredService<IPathMarkService>().Add(new PathMark
+        {
+            Path = _testRoot,
+            Type = PathMarkType.Property,
+            ConfigJson = JsonConvert.SerializeObject(new PropertyMarkConfig
+            {
+                MatchMode = PathMatchMode.Layer,
+                Layer = 1,
+                Pool = PropertyPool.Custom,
+                PropertyId = propertyId,
+                ValueType = PropertyValueType.Dynamic,
+                ValueLayer = 1,
+                ApplyScope = PathMarkApplyScope.MatchedOnly
+            }),
+            Priority = 50
+        });
+    }
+
+    private string BuildPropertyMarkConfig(int propertyId, string fixedValue)
+    {
+        return JsonConvert.SerializeObject(new PropertyMarkConfig
+        {
+            MatchMode = PathMatchMode.Layer,
+            Layer = 1,
+            Pool = PropertyPool.Custom,
+            PropertyId = propertyId,
+            ValueType = PropertyValueType.Fixed,
+            FixedValue = fixedValue,
+            ApplyScope = PathMarkApplyScope.MatchedOnly
+        });
+    }
+
+    private async Task SyncPendingPropertyMarks()
+    {
+        await _sp.GetRequiredService<PathMarkSyncService>().SyncMarks(
+            null,
+            null,
+            new PauseToken(),
+            CancellationToken.None);
+    }
+
+    private async Task RebuildSearchIndex()
+    {
+        var index = _sp.GetRequiredService<IResourceSearchIndexService>();
+        await index.RebuildAllAsync(CancellationToken.None);
+        await index.WaitForReadyAsync(TimeSpan.FromSeconds(10));
+    }
+
+    private async Task AssertReferenceSearchMatches(
+        int expectedResourceId,
+        CustomProperty property,
+        SearchOperation operation,
+        object dbValue)
+    {
+        var result = await _sp.GetRequiredService<IResourceService>().Search(new ResourceSearch
+        {
+            PageSize = 100,
+            Group = new ResourceSearchFilterGroup
+            {
+                Combinator = SearchCombinator.And,
+                Filters =
+                [
+                    new ResourceSearchFilter
+                    {
+                        PropertyPool = PropertyPool.Custom,
+                        PropertyId = property.Id,
+                        Operation = operation,
+                        DbValue = dbValue,
+                        Property = property.ToProperty()
+                    }
+                ]
+            }
+        });
+        result.Data.Should().ContainSingle(r => r.Id == expectedResourceId);
+    }
+}

--- a/src/tests/Bakabase.Tests/PathMarkSyncTests.cs
+++ b/src/tests/Bakabase.Tests/PathMarkSyncTests.cs
@@ -1778,9 +1778,8 @@ public class PathMarkSyncTests
     /// 对于引用类型（多选、单选、标签、多级），同步必须把文本转成选项并写入选项 id，
     /// 否则属性上一个选项都没有，资源筛选器里也就没有可选值。
     ///
-    /// 注意资源详情看起来是正常的：descriptor 读到无法匹配的 db value 会返回 null，
-    /// 但 Resource.Property.PropertyValue 会回退成原始 db value，于是原始文本被当成
-    /// 标签显示了出来 —— 这也是这个 bug 看起来只影响筛选器的原因。
+    /// 旧读取链路曾在 descriptor 无法匹配时回退成原始 db value，所以最初看起来
+    /// 只影响筛选器；移除该回退后，同一类表示错位也会直接显示成 UUID 标签。
     /// </summary>
     [TestMethod]
     public async Task PropertyMark_MultipleChoice_CreatesChoicesAndStoresChoiceIds()


### PR DESCRIPTION
Fixes #1321

## Summary

- Define custom-property mark effects as serialized business values while keeping media-library effects as ID strings.
- Convert V220 DB values when seeding effects and skip values that cannot be converted losslessly.
- Repair persisted reference effects by re-extracting values from the current mark configuration and resource path.
- Preserve ambiguous property values instead of guessing whether UUID-shaped text is a label or an ID.
- Update `Value` and `Priority` when an effect with the same key is synchronized again.
- Restore the original option IDs and filtering behavior for SingleChoice, MultipleChoice, Tags, and Multilevel properties.

## Safety

UUID-shaped text can be a legitimate business label, so the repair does not rely on UUID pattern matching.

Orphan UUID-labelled options previously created by beta.144 are intentionally retained because their provenance and current usage cannot be determined safely. The affected effects and resource values are repaired, but potentially user-owned options are not deleted automatically.

Media-library effects keep their existing ID-based contract and behavior.

## Tests

- Added four regression tests covering V220 legacy effects, beta.144 polluted data, same-key updates, UUID-shaped labels, all four reference property types, and resource filtering.
- Path-mark tests: 38/38 passed.
- New regression tests: 4/4 passed.
- Build completed with 0 errors.
- `git diff --check` passed.
