### PR TITLE
fix(search): synchronize path mark index updates

### DIFF
--- a/.claude/rules/resource-search-index.md
+++ b/.claude/rules/resource-search-index.md
@@ -113,7 +113,8 @@ Values are indexed in both:
 
 When `SearchResourceIdsAsync` returns `null`:
 1. Index not ready (during rebuild)
-2. No filter specified
+2. An incremental update failed and no successful full rebuild has recovered the index
+3. No filter specified
 
 The caller (ResourceService) falls back to full-scan search at `ResourceService.cs:188-218`.
 
@@ -132,6 +133,17 @@ RemoveResources(IEnumerable<int> resourceIds)
 ```
 
 Batch processing: 100 items max, 500ms max delay.
+
+`WaitForPendingUpdatesAsync` adds a FIFO barrier to the same channel. It completes only
+after every update queued before it has been applied; work queued after the barrier does
+not delay that wait. Workflows that promise immediately searchable results (for example,
+path-mark synchronization) must enqueue all affected resource IDs and await one barrier
+before reporting completion.
+
+Full rebuilds and incremental batches share a mutation gate so they cannot write the index
+at the same time. Incremental batches are retried up to three times. A permanently failed
+batch does not advance the index version, faults subsequent barriers, marks the index
+unavailable, and forces searches to use the full-scan fallback until a full rebuild succeeds.
 
 ## Key Files
 

--- a/src/abstractions/Bakabase.Abstractions/Services/IResourceSearchIndexService.cs
+++ b/src/abstractions/Bakabase.Abstractions/Services/IResourceSearchIndexService.cs
@@ -62,6 +62,15 @@ public interface IResourceSearchIndexService
     void RemoveResources(IEnumerable<int> resourceIds);
 
     /// <summary>
+    /// 等待调用此方法前已排队的增量索引更新全部处理完成。
+    /// </summary>
+    /// <remarks>
+    /// 这是一个 FIFO 屏障；在屏障之后排队的更新不会延迟本次等待。
+    /// 如果屏障之前的更新永久失败，该任务会抛出异常。
+    /// </remarks>
+    Task WaitForPendingUpdatesAsync(CancellationToken ct = default);
+
+    /// <summary>
     /// 全量重建索引
     /// </summary>
     Task RebuildAllAsync(CancellationToken ct = default);

--- a/src/legacy/Bakabase.InsideWorld.Business/Components/Search/Index/ResourceSearchIndexService.cs
+++ b/src/legacy/Bakabase.InsideWorld.Business/Components/Search/Index/ResourceSearchIndexService.cs
@@ -38,8 +38,8 @@ public class ResourceSearchIndexService : IResourceSearchIndexService
     private readonly ResourceSearchIndex _index = new();
 
     // Channel for async batch updates
-    private readonly Channel<IndexOperation> _operationChannel =
-        Channel.CreateUnbounded<IndexOperation>(new UnboundedChannelOptions
+    private readonly Channel<IndexQueueItem> _operationChannel =
+        Channel.CreateUnbounded<IndexQueueItem>(new UnboundedChannelOptions
         {
             SingleReader = true,
             SingleWriter = false
@@ -49,12 +49,22 @@ public class ResourceSearchIndexService : IResourceSearchIndexService
     private const int BatchSize = 100;
     private const int MaxDelayMs = 500;
     private const int MinBatchIntervalMs = 50;
+    private const int MaxBatchAttempts = 3;
 
     // State management
+    private readonly SemaphoreSlim _mutationGate = new(1, 1);
+    private readonly object _stateLock = new();
     private volatile bool _isReady;
     private TaskCompletionSource _readyTcs = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private Exception? _unrecoveredIndexFailure;
     private readonly CancellationTokenSource _backgroundCts = new();
     private Task? _backgroundTask;
+
+    private abstract record IndexQueueItem;
+
+    private sealed record OperationQueueItem(IndexOperation Operation) : IndexQueueItem;
+
+    private sealed record BarrierQueueItem(TaskCompletionSource Completion) : IndexQueueItem;
 
     public bool IsReady => _isReady;
     public long Version => _index.Version;
@@ -78,6 +88,76 @@ public class ResourceSearchIndexService : IResourceSearchIndexService
         _backgroundTask = ProcessOperationsAsync(_backgroundCts.Token);
     }
 
+    private static TaskCompletionSource CreateReadyCompletionSource() =>
+        new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    private Exception? GetUnrecoveredIndexFailure()
+    {
+        lock (_stateLock)
+        {
+            return _unrecoveredIndexFailure;
+        }
+    }
+
+    private void MarkIndexUnavailable(Exception failure)
+    {
+        TaskCompletionSource readyTcs;
+        lock (_stateLock)
+        {
+            _unrecoveredIndexFailure ??= failure;
+            _isReady = false;
+            if (_readyTcs.Task.IsCompleted)
+            {
+                _readyTcs = CreateReadyCompletionSource();
+            }
+            readyTcs = _readyTcs;
+        }
+
+        readyTcs.TrySetException(new InvalidOperationException("Resource search index update failed", failure));
+    }
+
+    private void BeginRebuild()
+    {
+        lock (_stateLock)
+        {
+            _isReady = false;
+            if (_readyTcs.Task.IsCompleted)
+            {
+                _readyTcs = CreateReadyCompletionSource();
+            }
+        }
+    }
+
+    private void CompleteRebuild()
+    {
+        TaskCompletionSource readyTcs;
+        lock (_stateLock)
+        {
+            _unrecoveredIndexFailure = null;
+            _isReady = true;
+            readyTcs = _readyTcs;
+        }
+
+        readyTcs.TrySetResult();
+    }
+
+    private void FailRebuild(Exception failure)
+    {
+        TaskCompletionSource readyTcs;
+        lock (_stateLock)
+        {
+            _unrecoveredIndexFailure = failure;
+            _isReady = false;
+            if (_readyTcs.Task.IsCompleted)
+            {
+                _readyTcs = CreateReadyCompletionSource();
+            }
+            readyTcs = _readyTcs;
+        }
+
+        readyTcs.TrySetException(new InvalidOperationException("Index rebuild failed", failure));
+    }
+
     private void OnResourceDataChanged(ResourceDataChangedEventArgs args)
     {
         InvalidateResources(args.ResourceIds);
@@ -92,27 +172,54 @@ public class ResourceSearchIndexService : IResourceSearchIndexService
 
     public void InvalidateResource(int resourceId)
     {
-        _operationChannel.Writer.TryWrite(new IndexOperation(IndexOperationType.Update, resourceId));
+        EnqueueOperation(new IndexOperation(IndexOperationType.Update, resourceId));
     }
 
     public void InvalidateResources(IEnumerable<int> resourceIds)
     {
         foreach (var resourceId in resourceIds)
         {
-            _operationChannel.Writer.TryWrite(new IndexOperation(IndexOperationType.Update, resourceId));
+            EnqueueOperation(new IndexOperation(IndexOperationType.Update, resourceId));
         }
     }
 
     public void RemoveResource(int resourceId)
     {
-        _operationChannel.Writer.TryWrite(new IndexOperation(IndexOperationType.Remove, resourceId));
+        EnqueueOperation(new IndexOperation(IndexOperationType.Remove, resourceId));
     }
 
     public void RemoveResources(IEnumerable<int> resourceIds)
     {
         foreach (var resourceId in resourceIds)
         {
-            _operationChannel.Writer.TryWrite(new IndexOperation(IndexOperationType.Remove, resourceId));
+            EnqueueOperation(new IndexOperation(IndexOperationType.Remove, resourceId));
+        }
+    }
+
+    public async Task WaitForPendingUpdatesAsync(CancellationToken ct = default)
+    {
+        ct.ThrowIfCancellationRequested();
+
+        var completion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        if (!_operationChannel.Writer.TryWrite(new BarrierQueueItem(completion)))
+        {
+            throw new InvalidOperationException("The resource search index update queue is not accepting work");
+        }
+
+        using var registration = ct.Register(() => completion.TrySetCanceled(ct));
+        await completion.Task;
+    }
+
+    private void EnqueueOperation(IndexOperation operation)
+    {
+        if (!_operationChannel.Writer.TryWrite(new OperationQueueItem(operation)))
+        {
+            _logger.LogError(
+                "Failed to enqueue {OperationType} operation for resource {ResourceId}",
+                operation.Type,
+                operation.ResourceId);
+            MarkIndexUnavailable(new InvalidOperationException(
+                $"Failed to enqueue {operation.Type} operation for resource {operation.ResourceId}"));
         }
     }
 
@@ -128,28 +235,51 @@ public class ResourceSearchIndexService : IResourceSearchIndexService
         {
             try
             {
-                batch.Clear();
-
                 // Wait for the first operation
-                if (await _operationChannel.Reader.WaitToReadAsync(ct))
+                if (!await _operationChannel.Reader.WaitToReadAsync(ct))
                 {
-                    // Collect a batch of operations (max wait MaxDelayMs)
-                    var deadline = DateTime.UtcNow.AddMilliseconds(MaxDelayMs);
+                    break;
+                }
 
-                    while (batch.Count < BatchSize &&
-                           DateTime.UtcNow < deadline &&
-                           _operationChannel.Reader.TryRead(out var op))
+                batch.Clear();
+                var deadline = DateTime.UtcNow.AddMilliseconds(MaxDelayMs);
+                var processedOperations = false;
+
+                while (batch.Count < BatchSize &&
+                       DateTime.UtcNow < deadline &&
+                       _operationChannel.Reader.TryRead(out var item))
+                {
+                    if (item is OperationQueueItem operationItem)
                     {
-                        batch.Add(op);
+                        batch.Add(operationItem.Operation);
+                        continue;
                     }
 
+                    var barrier = (BarrierQueueItem)item;
+
+                    // A batch must never cross a barrier. Apply everything collected before
+                    // it, then complete the barrier before reading any subsequent work.
                     if (batch.Count > 0)
                     {
-                        await ProcessBatchAsync(batch, ct);
-
-                        // Brief pause between batches to avoid resource overuse
-                        await Task.Delay(MinBatchIntervalMs, ct);
+                        await ProcessBatchWithRetryAsync(batch, ct);
+                        batch.Clear();
+                        processedOperations = true;
                     }
+
+                    await CompleteBarrierAsync(barrier, ct);
+                    break;
+                }
+
+                if (batch.Count > 0)
+                {
+                    await ProcessBatchWithRetryAsync(batch, ct);
+                    processedOperations = true;
+                }
+
+                if (processedOperations)
+                {
+                    // Brief pause between batches to avoid resource overuse
+                    await Task.Delay(MinBatchIntervalMs, ct);
                 }
             }
             catch (OperationCanceledException) when (ct.IsCancellationRequested)
@@ -161,6 +291,85 @@ public class ResourceSearchIndexService : IResourceSearchIndexService
                 _logger.LogError(ex, "Error processing index operations batch");
                 await Task.Delay(1000, ct); // Wait before retrying
             }
+        }
+    }
+
+    private async Task ProcessBatchWithRetryAsync(List<IndexOperation> operations, CancellationToken ct)
+    {
+        Exception? lastError = null;
+
+        await _mutationGate.WaitAsync(ct);
+        try
+        {
+            for (var attempt = 1; attempt <= MaxBatchAttempts; attempt++)
+            {
+                ct.ThrowIfCancellationRequested();
+                try
+                {
+                    await ProcessBatchAsync(operations, ct);
+                    return;
+                }
+                catch (OperationCanceledException) when (ct.IsCancellationRequested)
+                {
+                    throw;
+                }
+                catch (Exception ex)
+                {
+                    lastError = ex;
+                    _logger.LogWarning(ex,
+                        "Resource search index batch failed on attempt {Attempt}/{MaxAttempts}",
+                        attempt,
+                        MaxBatchAttempts);
+                }
+
+                if (attempt < MaxBatchAttempts)
+                {
+                    await Task.Delay(TimeSpan.FromMilliseconds(100 * attempt), ct);
+                }
+            }
+
+            var failure = new InvalidOperationException(
+                $"Resource search index batch failed after {MaxBatchAttempts} attempts",
+                lastError);
+            MarkIndexUnavailable(failure);
+            _logger.LogError(failure, "Resource search index is unavailable until a full rebuild succeeds");
+        }
+        finally
+        {
+            _mutationGate.Release();
+        }
+    }
+
+    private async Task CompleteBarrierAsync(BarrierQueueItem barrier, CancellationToken ct)
+    {
+        try
+        {
+            // Even an empty barrier must pass through the writer gate so it cannot complete
+            // while a full rebuild is still mutating the index.
+            await _mutationGate.WaitAsync(ct);
+            try
+            {
+                var failure = GetUnrecoveredIndexFailure();
+                if (failure == null)
+                {
+                    barrier.Completion.TrySetResult();
+                }
+                else
+                {
+                    barrier.Completion.TrySetException(new InvalidOperationException(
+                        "A resource search index update before this barrier failed",
+                        failure));
+                }
+            }
+            finally
+            {
+                _mutationGate.Release();
+            }
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            barrier.Completion.TrySetCanceled(ct);
+            throw;
         }
     }
 
@@ -261,6 +470,9 @@ public class ResourceSearchIndexService : IResourceSearchIndexService
 
                 // 2. Build new index
                 var indexKeys = new HashSet<IndexKey>();
+                // Register the live key set before adding entries so a retry can remove
+                // everything written by a partially completed attempt.
+                _index.ResourceIndexKeys[resourceId] = indexKeys;
 
                 // Index internal properties
                 var dbModel = dbResourceMap.GetValueOrDefault(resourceId);
@@ -298,8 +510,7 @@ public class ResourceSearchIndexService : IResourceSearchIndexService
                     }
                 }
 
-                // 3. Save index key mapping
-                _index.ResourceIndexKeys[resourceId] = indexKeys;
+                // 3. Mark the resource as fully indexed
                 lock (_index.AllResourceIdsLock)
                 {
                     _index.AllResourceIds.Add(resourceId);
@@ -310,6 +521,7 @@ public class ResourceSearchIndexService : IResourceSearchIndexService
         {
             _logger.LogError(ex, "Error updating index for resources: {ResourceIds}",
                 string.Join(",", resourceIds.Take(10)));
+            throw;
         }
     }
 
@@ -611,11 +823,10 @@ public class ResourceSearchIndexService : IResourceSearchIndexService
     /// <param name="ct">取消令牌</param>
     public async Task RebuildAllAsync(Func<int, string?, Task>? progressCallback, CancellationToken ct = default)
     {
-        _isReady = false;
-        _readyTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-
+        await _mutationGate.WaitAsync(ct);
         try
         {
+            BeginRebuild();
             var sw = Stopwatch.StartNew();
             using var scope = _scopeFactory.CreateScope();
 
@@ -717,7 +928,10 @@ public class ResourceSearchIndexService : IResourceSearchIndexService
                 }
 
                 _index.ResourceIndexKeys[resource.Id] = indexKeys;
-                _index.AllResourceIds.Add(resource.Id);
+                lock (_index.AllResourceIdsLock)
+                {
+                    _index.AllResourceIds.Add(resource.Id);
+                }
                 indexedCount++;
 
                 // Report progress every 5%
@@ -734,11 +948,6 @@ public class ResourceSearchIndexService : IResourceSearchIndexService
 
             _logger.LogInformation("Indexed {Count} resources in {Ms}ms", indexedCount, sw.ElapsedMilliseconds);
 
-            _index.Version++;
-            _index.LastUpdatedAt = DateTime.UtcNow;
-            _isReady = true;
-            _readyTcs.TrySetResult();
-
             await ReportProgress(progressCallback, 100, _localizer.SearchIndex_Completed(indexedCount));
 
             _logger.LogInformation(
@@ -746,11 +955,19 @@ public class ResourceSearchIndexService : IResourceSearchIndexService
                 _index.AllResourceIds.Count,
                 _index.GetValueIndexEntryCount(),
                 _index.GetRangeIndexEntryCount());
+
+            _index.Version++;
+            _index.LastUpdatedAt = DateTime.UtcNow;
+            CompleteRebuild();
         }
         catch (Exception ex)
         {
-            _readyTcs.TrySetException(new InvalidOperationException("Index rebuild failed", ex));
+            FailRebuild(ex);
             throw;
+        }
+        finally
+        {
+            _mutationGate.Release();
         }
     }
 
@@ -764,9 +981,20 @@ public class ResourceSearchIndexService : IResourceSearchIndexService
 
     public async Task WaitForReadyAsync(TimeSpan? timeout = null)
     {
-        if (_isReady) return;
+        Task task;
+        Exception? failure;
+        lock (_stateLock)
+        {
+            if (_isReady) return;
+            failure = _unrecoveredIndexFailure;
+            task = _readyTcs.Task;
+        }
 
-        var task = _readyTcs.Task;
+        if (failure != null)
+        {
+            throw new InvalidOperationException("The resource search index is unavailable", failure);
+        }
+
         if (timeout.HasValue)
         {
             using var cts = new CancellationTokenSource(timeout.Value);
@@ -836,6 +1064,11 @@ public class ResourceSearchIndexService : IResourceSearchIndexService
             return null; // No filter, return null to indicate "all"
         }
 
+        if (GetUnrecoveredIndexFailure() != null)
+        {
+            return null; // A failed incremental update makes the index unsafe; use the full scan.
+        }
+
         if (!IsReady)
         {
             // Wait up to 1 second for index to be ready
@@ -848,6 +1081,17 @@ public class ResourceSearchIndexService : IResourceSearchIndexService
                 _logger.LogWarning("Search index not ready, falling back to full scan");
                 return null; // Fallback to full search
             }
+            catch (InvalidOperationException ex)
+            {
+                _logger.LogWarning(ex, "Search index unavailable, falling back to full scan");
+                return null;
+            }
+        }
+
+        // The state may have changed while readiness was being awaited.
+        if (!IsReady || GetUnrecoveredIndexFailure() != null)
+        {
+            return null;
         }
 
         return EvaluateFilterGroup(group);

--- a/src/legacy/Bakabase.InsideWorld.Business/Services/PathMarkSyncService.cs
+++ b/src/legacy/Bakabase.InsideWorld.Business/Services/PathMarkSyncService.cs
@@ -47,6 +47,7 @@ public class PathMarkSyncService : ScopedService
 {
     private readonly IPathMarkService _pathMarkService;
     private readonly IResourceService _resourceService;
+    private readonly IResourceSearchIndexService _resourceSearchIndexService;
     private readonly IMediaLibraryResourceMappingService _mappingService;
     private readonly IMediaLibraryV2Service _mediaLibraryV2Service;
     private readonly ICustomPropertyValueService _customPropertyValueService;
@@ -60,6 +61,7 @@ public class PathMarkSyncService : ScopedService
         IServiceProvider serviceProvider,
         IPathMarkService pathMarkService,
         IResourceService resourceService,
+        IResourceSearchIndexService resourceSearchIndexService,
         IMediaLibraryResourceMappingService mappingService,
         IMediaLibraryV2Service mediaLibraryV2Service,
         ICustomPropertyValueService customPropertyValueService,
@@ -71,6 +73,7 @@ public class PathMarkSyncService : ScopedService
     {
         _pathMarkService = pathMarkService;
         _resourceService = resourceService;
+        _resourceSearchIndexService = resourceSearchIndexService;
         _mappingService = mappingService;
         _mediaLibraryV2Service = mediaLibraryV2Service;
         _customPropertyValueService = customPropertyValueService;
@@ -295,6 +298,8 @@ public class PathMarkSyncService : ScopedService
             // ===== Cleanup (95-100%) =====
             await ReportProgress(onProgressChange, onProcessChange, 95, "Updating mark statuses...");
             await BatchUpdateMarkStatuses(ctx, marksToDelete);
+
+            await _resourceSearchIndexService.WaitForPendingUpdatesAsync(ct);
 
             await ReportProgress(onProgressChange, onProcessChange, 100, _localizer.SyncPathMark_Complete());
         }
@@ -956,6 +961,7 @@ public class PathMarkSyncService : ScopedService
         var distinctDeletes = ctx.PropertyValuesToDelete.Distinct().ToList();
         if (distinctDeletes.Count > 0)
         {
+            var deletedResourceIds = new HashSet<int>();
             foreach (var (resourceId, propertyId) in distinctDeletes)
             {
                 ct.ThrowIfCancellationRequested();
@@ -963,6 +969,14 @@ public class PathMarkSyncService : ScopedService
                     x.ResourceId == resourceId &&
                     x.PropertyId == propertyId &&
                     x.Scope == (int)PropertyValueScope.Synchronization);
+                // Reindex even when the delete was already idempotently satisfied: an
+                // older failed update may still have left this value in the index.
+                deletedResourceIds.Add(resourceId);
+            }
+
+            if (deletedResourceIds.Count > 0)
+            {
+                _resourceSearchIndexService.InvalidateResources(deletedResourceIds);
             }
 
             deleted = distinctDeletes.Count;

--- a/src/tests/Bakabase.Tests/PathMarkReferenceValueRegressionTests.cs
+++ b/src/tests/Bakabase.Tests/PathMarkReferenceValueRegressionTests.cs
@@ -22,6 +22,8 @@ using Bakabase.Modules.Property.Components.Properties.Multilevel;
 using Bakabase.Modules.Property.Components.Properties.Tags;
 using Bakabase.Modules.Property.Extensions;
 using Bakabase.Modules.StandardValue.Extensions;
+using Bakabase.Service.Extensions;
+using Bakabase.Service.Models.Input;
 using Bakabase.TestKit.Utils;
 using Bootstrap.Components.Tasks;
 using FluentAssertions;
@@ -67,6 +69,27 @@ public sealed class PathMarkReferenceValueRegressionTests
                 // Best-effort cleanup. A failed assertion should remain the test's failure.
             }
         }
+    }
+
+    [TestMethod]
+    public async Task SearchInput_SingleChoiceIn_DeserializesSerializedListStringAtTheApiBoundary()
+    {
+        var choiceId = Guid.NewGuid().ToString();
+        var property = await AddProperty(
+            "Single choice API filter",
+            PropertyType.SingleChoice,
+            new SingleChoicePropertyOptions
+            {
+                Choices = [new ChoiceOptions {Label = "Action", Value = choiceId}]
+            });
+
+        var search = await BuildSingleChoiceInApiSearch(property.Id, choiceId);
+
+        var filter = search.Group!.Filters.Should().ContainSingle().Subject;
+        filter.Property.Should().NotBeNull();
+        filter.Property!.Type.Should().Be(PropertyType.SingleChoice);
+        filter.Operation.Should().Be(SearchOperation.In);
+        filter.DbValue.Should().BeOfType<List<string>>().Subject.Should().Equal(choiceId);
     }
 
     [TestMethod]
@@ -299,7 +322,19 @@ public sealed class PathMarkReferenceValueRegressionTests
 
         var triggerProperty = await AddProperty("Partial-sync trigger", PropertyType.SingleLineText);
         await AddPropertyMark(triggerProperty.Id, "touch");
+
+        // The index must contain the beta.144 state before partial sync starts. Rebuilding
+        // afterwards would hide the incremental-update consistency window reported by users.
+        await RebuildSearchIndex();
+        await AssertSingleChoiceInSearchMatches(resource.Id, property.Id, pollutedChoiceId);
+        await AssertSingleChoiceInSearchDoesNotMatch(property.Id, originalChoiceId);
+
         await SyncPendingPropertyMarks();
+
+        // This is intentionally the first operation after SyncMarks returns: no delay,
+        // polling, or full rebuild may mask an update that is still queued or in flight.
+        await AssertSingleChoiceInSearchMatches(resource.Id, property.Id, originalChoiceId);
+        await AssertSingleChoiceInSearchDoesNotMatch(property.Id, pollutedChoiceId);
 
         var refreshedProperty = await propertyService.GetByKey(property.Id);
         var refreshedOptions = refreshedProperty.Options.Should()
@@ -327,10 +362,46 @@ public sealed class PathMarkReferenceValueRegressionTests
             .Values!.Should().ContainSingle(v => v.Scope == (int) PropertyValueScope.Synchronization).Subject;
         reloadedValue.Value.Should().Be(originalChoiceId);
         reloadedValue.BizValue.Should().Be("Action");
+    }
+
+    [TestMethod]
+    public async Task Resync_PropertyMarkWithoutMatches_RemovesValueFromReadyIndexBeforeSyncReturns()
+    {
+        var resourceService = _sp.GetRequiredService<IResourceService>();
+        var propertyService = _sp.GetRequiredService<ICustomPropertyService>();
+        var propertyValueService = _sp.GetRequiredService<ICustomPropertyValueService>();
+        var pathMarkService = _sp.GetRequiredService<IPathMarkService>();
+
+        var resourcePath = Path.Combine(_testRoot, "Movie");
+        Directory.CreateDirectory(resourcePath);
+        await resourceService.AddOrPutRange([new Resource {Path = resourcePath, IsFile = false}]);
+        var resource = (await resourceService.GetAll()).Should().ContainSingle().Subject;
+
+        var property = await AddProperty("Deleted property mark", PropertyType.SingleChoice);
+        var mark = await AddPropertyMark(property.Id, "Action");
+        await SyncPendingPropertyMarks();
+
+        var refreshedProperty = await propertyService.GetByKey(property.Id);
+        var choiceId = refreshedProperty.Options.Should()
+            .BeOfType<SingleChoicePropertyOptions>().Subject.Choices.Should()
+            .ContainSingle(c => c.Label == "Action").Which.Value;
 
         await RebuildSearchIndex();
-        await AssertReferenceSearchMatches(resource.Id, refreshedProperty,
-            SearchOperation.Equals, originalChoiceId);
+        await AssertSingleChoiceInSearchMatches(resource.Id, property.Id, choiceId);
+
+        mark.Path = Path.Combine(_testRoot, "NoLongerMatches");
+        await pathMarkService.Update(mark);
+        await SyncPendingPropertyMarks();
+
+        // The resource still exists, but its removed synchronization value must not remain
+        // searchable after the successful re-sync reports completion.
+        await AssertSingleChoiceInSearchDoesNotMatch(property.Id, choiceId);
+        (await resourceService.GetAll()).Should().ContainSingle(r => r.Id == resource.Id);
+        (await propertyValueService.GetAllDbModels(v =>
+                v.ResourceId == resource.Id &&
+                v.PropertyId == property.Id &&
+                v.Scope == (int) PropertyValueScope.Synchronization))
+            .Should().BeEmpty();
     }
 
     [TestMethod]
@@ -548,6 +619,64 @@ public sealed class PathMarkReferenceValueRegressionTests
         var index = _sp.GetRequiredService<IResourceSearchIndexService>();
         await index.RebuildAllAsync(CancellationToken.None);
         await index.WaitForReadyAsync(TimeSpan.FromSeconds(10));
+    }
+
+    private async Task<ResourceSearch> BuildSingleChoiceInApiSearch(int propertyId, params string[] choiceIds)
+    {
+        var serializedList = choiceIds.ToList().SerializeAsStandardValue(StandardValueType.ListString);
+        serializedList.Should().NotBeNull();
+
+        var input = new ResourceSearchInputModel
+        {
+            Page = 1,
+            PageSize = 100,
+            Group = new ResourceSearchFilterGroupInputModel
+            {
+                Combinator = SearchCombinator.And,
+                Filters =
+                [
+                    new ResourceSearchFilterInputModel
+                    {
+                        PropertyPool = PropertyPool.Custom,
+                        PropertyId = propertyId,
+                        Operation = SearchOperation.In,
+                        DbValue = serializedList
+                    }
+                ]
+            }
+        };
+
+        return await input.ToDomainModel(_sp.GetRequiredService<IPropertyService>());
+    }
+
+    private async Task AssertSingleChoiceInSearchMatches(
+        int expectedResourceId,
+        int propertyId,
+        string choiceId)
+    {
+        var search = await BuildSingleChoiceInApiSearch(propertyId, choiceId);
+        var indexedIds = await _sp.GetRequiredService<IResourceSearchIndexService>()
+            .SearchResourceIdsAsync(search.Group);
+        indexedIds.Should().NotBeNull(
+            "the ready inverted index must answer the filter instead of allowing a full-scan fallback");
+        indexedIds!.Should().ContainSingle(id => id == expectedResourceId);
+
+        var result = await _sp.GetRequiredService<IResourceService>().Search(search);
+        result.Data.Should().ContainSingle(r => r.Id == expectedResourceId);
+    }
+
+    private async Task AssertSingleChoiceInSearchDoesNotMatch(int propertyId, string choiceId)
+    {
+        var search = await BuildSingleChoiceInApiSearch(propertyId, choiceId);
+        var indexedIds = await _sp.GetRequiredService<IResourceSearchIndexService>()
+            .SearchResourceIdsAsync(search.Group);
+        indexedIds.Should().NotBeNull(
+            "the ready inverted index must answer the filter instead of allowing a full-scan fallback");
+        indexedIds!.Should().BeEmpty();
+
+        var result = await _sp.GetRequiredService<IResourceService>().Search(search);
+        result.Data.Should().NotBeNull();
+        result.Data!.Count.Should().Be(0);
     }
 
     private async Task AssertReferenceSearchMatches(

--- a/src/tests/Bakabase.Tests/ResourceSearchIndexIncrementalTests.cs
+++ b/src/tests/Bakabase.Tests/ResourceSearchIndexIncrementalTests.cs
@@ -1,19 +1,22 @@
 using System;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
+using Bakabase.Abstractions.Components.Events;
+using Bakabase.Abstractions.Components.Localization;
 using Bakabase.Abstractions.Models.Domain;
 using Bakabase.Abstractions.Models.Domain.Constants;
 using Bakabase.Abstractions.Services;
+using Bakabase.InsideWorld.Business.Components.Search.Index;
 using Bakabase.InsideWorld.Business.Services;
 using Bakabase.InsideWorld.Models.Constants.Aos;
 using Bakabase.Modules.Property.Abstractions.Services;
 using Bakabase.TestKit.Utils;
 using Bootstrap.Components.Tasks;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 
 namespace Bakabase.Tests;
@@ -82,20 +85,13 @@ public sealed class ResourceSearchIndexIncrementalTests
         var idx = Index();
         await idx.RebuildAllAsync(CancellationToken.None);
         await idx.WaitForReadyAsync(TimeSpan.FromSeconds(10));
-        // Let invalidations queued during seeding drain before assertions.
-        await Task.Delay(800);
+        await idx.WaitForPendingUpdatesAsync(CancellationToken.None);
     }
 
-    /// <summary>Polls the indexed-resource count until it reaches <paramref name="expected"/>.</summary>
-    private async Task WaitForIndexedCount(int expected)
+    private async Task WaitForPendingUpdatesAndAssertCount(int expected)
     {
-        var sw = Stopwatch.StartNew();
-        while (sw.Elapsed < TimeSpan.FromSeconds(8))
-        {
-            if (Index().GetStatus().TotalResourceCount == expected) return;
-            await Task.Delay(50);
-        }
-        Assert.AreEqual(expected, Index().GetStatus().TotalResourceCount, "indexed count did not converge");
+        await Index().WaitForPendingUpdatesAsync(CancellationToken.None);
+        Assert.AreEqual(expected, Index().GetStatus().TotalResourceCount);
     }
 
     private async Task<int> ResourceId(string filename)
@@ -133,7 +129,7 @@ public sealed class ResourceSearchIndexIncrementalTests
         Assert.AreEqual(3, Index().GetStatus().TotalResourceCount);
 
         Index().RemoveResource(await ResourceId("a"));
-        await WaitForIndexedCount(2);
+        await WaitForPendingUpdatesAndAssertCount(2);
     }
 
     [TestMethod]
@@ -144,7 +140,7 @@ public sealed class ResourceSearchIndexIncrementalTests
         Assert.AreEqual(1, await SearchCountByFilename("apple"));
 
         Index().RemoveResource(await ResourceId("apple"));
-        await WaitForIndexedCount(1);
+        await WaitForPendingUpdatesAndAssertCount(1);
 
         Assert.AreEqual(0, await SearchCountByFilename("apple"));
     }
@@ -156,7 +152,7 @@ public sealed class ResourceSearchIndexIncrementalTests
         await BuildIndex();
 
         Index().RemoveResources([await ResourceId("a"), await ResourceId("b")]);
-        await WaitForIndexedCount(1);
+        await WaitForPendingUpdatesAndAssertCount(1);
     }
 
     [TestMethod]
@@ -166,7 +162,7 @@ public sealed class ResourceSearchIndexIncrementalTests
         await BuildIndex();
 
         Index().RemoveResource(await ResourceId("apple"));
-        await WaitForIndexedCount(1);
+        await WaitForPendingUpdatesAndAssertCount(1);
 
         Assert.AreEqual(1, await SearchCountByFilename("banana"));
     }
@@ -179,11 +175,11 @@ public sealed class ResourceSearchIndexIncrementalTests
         var id = await ResourceId("a");
 
         Index().RemoveResource(id);
-        await WaitForIndexedCount(1);
+        await WaitForPendingUpdatesAndAssertCount(1);
 
         // The resource still exists in the database; invalidation must re-read and re-index it.
         Index().InvalidateResource(id);
-        await WaitForIndexedCount(2);
+        await WaitForPendingUpdatesAndAssertCount(2);
     }
 
     [TestMethod]
@@ -194,8 +190,104 @@ public sealed class ResourceSearchIndexIncrementalTests
         var versionBefore = Index().Version;
 
         Index().RemoveResource(await ResourceId("a"));
-        await WaitForIndexedCount(1);
+        await WaitForPendingUpdatesAndAssertCount(1);
 
         Assert.IsTrue(Index().Version > versionBefore);
+    }
+
+    [TestMethod]
+    public async Task WaitForPendingUpdates_WaitsAcrossBatchBoundary()
+    {
+        await Seed("a", "b");
+        await BuildIndex();
+        var id = await ResourceId("a");
+
+        for (var i = 0; i < 100; i++)
+        {
+            Index().InvalidateResource(id);
+        }
+        Index().RemoveResource(id);
+
+        // The remove is the 101st operation, so it must be processed in the batch after
+        // the first 100 invalidations before the FIFO barrier can complete.
+        await WaitForPendingUpdatesAndAssertCount(1);
+        Assert.AreEqual(0, await SearchCountByFilename("a"));
+    }
+
+    [TestMethod]
+    public async Task IncrementalBatch_RetriesThenFallsBackUntilSuccessfulRebuild()
+    {
+        await Seed("a");
+        var scopeFactory = new FailNextScopeFactory(_sp.GetRequiredService<IServiceScopeFactory>());
+        var index = new ResourceSearchIndexService(
+            scopeFactory,
+            _sp.GetRequiredService<IResourceDataChangeEvent>(),
+            _sp.GetRequiredService<ILogger<ResourceSearchIndexService>>(),
+            _sp.GetRequiredService<IBakabaseLocalizer>());
+
+        await index.RebuildAllAsync(CancellationToken.None);
+        var versionBeforeRetry = index.Version;
+        scopeFactory.FailNext(2);
+
+        index.InvalidateResource(await ResourceId("a"));
+        await index.WaitForPendingUpdatesAsync(CancellationToken.None);
+
+        Assert.IsTrue(index.IsReady);
+        Assert.AreEqual(versionBeforeRetry + 1, index.Version,
+            "two failed attempts followed by a successful retry must advance the version once");
+
+        var versionBeforeFailure = index.Version;
+        scopeFactory.FailNext(3);
+
+        index.InvalidateResource(await ResourceId("a"));
+        await Assert.ThrowsExceptionAsync<InvalidOperationException>(
+            () => index.WaitForPendingUpdatesAsync(CancellationToken.None));
+
+        Assert.IsFalse(index.IsReady);
+        Assert.AreEqual(versionBeforeFailure, index.Version,
+            "a failed batch must not advance the observable index version");
+
+        var filter = new ResourceSearchFilterGroup
+        {
+            Combinator = SearchCombinator.And,
+            Filters =
+            [
+                new ResourceSearchFilter
+                {
+                    PropertyPool = PropertyPool.Internal,
+                    PropertyId = (int)InternalProperty.Filename,
+                    Operation = SearchOperation.Equals,
+                    DbValue = "a",
+                    Property = _filenameProperty
+                }
+            ]
+        };
+        Assert.IsNull(await index.SearchResourceIdsAsync(filter),
+            "an index with an unrecovered batch failure must force the caller to full-scan");
+
+        await index.RebuildAllAsync(CancellationToken.None);
+        await index.WaitForReadyAsync(TimeSpan.FromSeconds(10));
+
+        Assert.IsTrue(index.IsReady);
+        CollectionAssert.AreEqual(
+            new[] {await ResourceId("a")},
+            (await index.SearchResourceIdsAsync(filter))!.OrderBy(x => x).ToArray());
+    }
+
+    private sealed class FailNextScopeFactory(IServiceScopeFactory inner) : IServiceScopeFactory
+    {
+        private int _remainingFailures;
+
+        public void FailNext(int count) => Volatile.Write(ref _remainingFailures, count);
+
+        public IServiceScope CreateScope()
+        {
+            if (Interlocked.Decrement(ref _remainingFailures) >= 0)
+            {
+                throw new InvalidOperationException("Injected scope creation failure");
+            }
+
+            return inner.CreateScope();
+        }
     }
 }


### PR DESCRIPTION
## Summary

- Wait for queued resource-search index mutations before path-mark synchronization reports completion.
- Retry failed incremental batches, serialize incremental writes with full rebuilds, and fall back to full scans until a successful rebuild recovers the index.
- Invalidate index entries for path-mark property-value deletions and add regression coverage for SingleChoice In filters, repaired legacy values, deletions, batching, retries, and recovery.

## Root cause

Path-mark synchronization could commit corrected property values and return while the asynchronous search index still contained the old standard value. SingleChoice In filtering then queried the stale value and returned an empty resource set.

## Testing

- Bakabase.Tests build in .NET 9 Docker: 0 errors
- Focused path-mark and index regression suite: 14 passed
- Resource search, path-mark sync, and property-value count suite: 69 passed

Fixes #1325