### PR TITLE
fix(updater): align Velopack with packaging CLI

### DIFF
--- a/src/apps/Bakabase/Bakabase.csproj
+++ b/src/apps/Bakabase/Bakabase.csproj
@@ -16,7 +16,7 @@
         <PackageReference Include="Avalonia.Themes.Fluent" Version="11.3.20" />
         <PackageReference Include="HttpCloak" Version="1.6.1" />
         <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.3856.49" Condition="$([MSBuild]::IsOSPlatform('Windows'))" />
-        <PackageReference Include="Velopack" Version="0.0.1298" />
+        <PackageReference Include="Velopack" Version="1.2.0" />
         <PackageReference Include="Nerdbank.GitVersioning" Version="3.7.115">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
## Summary

- upgrade the desktop Velopack package reference from 0.0.1298 to 1.2.0
- advance the Bakabase.Infrastructures submodule to its merged Velopack 1.2.0 update
- keep the managed libraries aligned with the vpk 1.2.0 binaries used by the release workflow

## Validation

- xmllint --noout on both changed project files
- git diff --check
- containerized .NET 9 build of Bakabase.Infrastructures with BuildProjectReferences=false: 0 errors
- containerized .NET 9 build of the Bakabase desktop entry point with BuildProjectReferences=false: 0 errors
- verified the generated Bakabase.deps.json resolves Velopack/1.2.0
- GitHub Actions CI: Backend tests and Frontend lint & tests passed

Fixes #1301