### PR TITLE
feat(property): hide zero counts and disable unused filter choices

### DIFF
--- a/src/web/src/components/Property/__tests__/referenceValueAvailability.test.tsx
+++ b/src/web/src/components/Property/__tests__/referenceValueAvailability.test.tsx
@@ -1,0 +1,209 @@
+import type { Props } from "@/components/Property/components/PropertyValueRenderer";
+
+import { act } from "react-dom/test-utils";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import ReferenceValueCount from "../components/ReferenceValueCount";
+
+import ReferencePropertyValueInput from "@/components/ResourceFilter/components/Filter/ReferencePropertyValueInput";
+import ReferenceValueUsage, {
+  ReferenceValueUsageProvider,
+} from "@/components/PropertyModal/components/ReferenceValueUsage";
+import { PropertyPool, PropertyType, StandardValueType } from "@/sdk/constants";
+
+const state = vi.hoisted(() => ({
+  globalCounts: undefined as Record<string, number> | undefined,
+  filteredCounts: undefined as Record<string, number> | undefined,
+  search: undefined as { keyword: string } | undefined,
+  rendererProps: undefined as Props | undefined,
+  createPortal: vi.fn(),
+}));
+
+vi.mock("react-i18next", () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
+vi.mock("@/components/Property/components/PropertyValueRenderer", () => ({
+  default: (props: Props) => {
+    state.rendererProps = props;
+
+    return null;
+  },
+}));
+vi.mock("@/hooks/useReferenceValueResourceCounts", () => ({
+  useReferenceValueSearch: () => state.search,
+  referenceValueCountsCriteria: (search?: { keyword: string }) => search ?? {},
+  useReferenceValueResourceCounts: (property?: unknown, search?: unknown) => ({
+    counts: property ? (search ? state.filteredCounts : state.globalCounts) : undefined,
+    source: undefined,
+    loading: false,
+    error: false,
+    refresh: vi.fn(),
+  }),
+}));
+vi.mock("@/components/ContextProvider/BakabaseContextProvider", () => ({
+  useBakabaseContext: () => ({ createPortal: state.createPortal }),
+}));
+vi.mock("@/components/PropertyModal/components/ReferenceValueResourcesModal", () => ({
+  default: () => null,
+}));
+vi.mock("@/components/bakaui", () => ({
+  Button: ({ children, isDisabled, onPress, title, "aria-label": ariaLabel }: any) => (
+    <button aria-label={ariaLabel} disabled={isDisabled} title={title} onClick={onPress}>
+      {children}
+    </button>
+  ),
+}));
+
+const property: Props["property"] = {
+  id: 1,
+  pool: PropertyPool.Custom,
+  type: PropertyType.SingleChoice,
+  name: "Genre",
+  dbValueType: StandardValueType.String,
+  bizValueType: StandardValueType.String,
+  typeName: "SingleChoice",
+  poolName: "Custom",
+  order: 0,
+};
+let container: HTMLDivElement;
+let root: ReturnType<typeof createRoot>;
+
+beforeEach(() => {
+  (globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+  state.globalCounts = undefined;
+  state.filteredCounts = undefined;
+  state.search = undefined;
+  state.rendererProps = undefined;
+  state.createPortal.mockClear();
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+afterEach(async () => {
+  await act(async () => root.unmount());
+  container.remove();
+});
+
+describe("reference option availability", () => {
+  it("keeps a valid replacement enabled when its current-filter count is zero", async () => {
+    state.search = { keyword: "current filter" };
+    state.globalCounts = { selected: 2, replacement: 7, unused: 0 };
+    state.filteredCounts = { selected: 2, replacement: 0, unused: 0 };
+    await act(async () =>
+      root.render(<ReferencePropertyValueInput dbValue="selected" property={property} />),
+    );
+
+    expect(state.rendererProps?.resourceCounts).toEqual(state.filteredCounts);
+    expect([...state.rendererProps!.disabledKeys!]).toEqual(["unused"]);
+    expect(state.rendererProps!.disabledKeysSource!.getSnapshot()?.has("replacement")).toBe(false);
+  });
+
+  it("does not turn missing or unavailable counts into disabled choices", async () => {
+    state.search = { keyword: "current filter" };
+    state.filteredCounts = { choice: 0 };
+    await act(async () => root.render(<ReferencePropertyValueInput property={property} />));
+    expect(state.rendererProps?.disabledKeys).toBeUndefined();
+
+    state.globalCounts = { known: 3 };
+    await act(async () => root.render(<ReferencePropertyValueInput property={property} />));
+    expect(state.rendererProps?.disabledKeys?.has("choice")).toBe(false);
+  });
+
+  it("keeps the displayed count source connected when switching between global and filtered counts", async () => {
+    state.globalCounts = { choice: 7 };
+    await act(async () => root.render(<ReferencePropertyValueInput property={property} />));
+    const source = state.rendererProps!.resourceCountsSource!;
+
+    expect(source.getSnapshot()).toEqual({ choice: 7 });
+
+    state.search = { keyword: "limited" };
+    state.filteredCounts = { choice: 0 };
+    await act(async () => root.render(<ReferencePropertyValueInput property={property} />));
+    expect(state.rendererProps!.resourceCountsSource).toBe(source);
+    expect(source.getSnapshot()).toEqual({ choice: 0 });
+
+    state.search = undefined;
+    await act(async () => root.render(<ReferencePropertyValueInput property={property} />));
+    expect(state.rendererProps!.resourceCountsSource).toBe(source);
+    expect(source.getSnapshot()).toEqual({ choice: 7 });
+  });
+
+  it("publishes changes to the existing disabled source and retains explicit restrictions", async () => {
+    const disabledKeys = new Set(["explicit"]);
+
+    state.globalCounts = { unused: 0 };
+    await act(async () =>
+      root.render(<ReferencePropertyValueInput disabledKeys={disabledKeys} property={property} />),
+    );
+    const source = state.rendererProps!.disabledKeysSource!;
+    const listener = vi.fn();
+    const unsubscribe = source.subscribe(listener);
+
+    expect(source.getSnapshot()).toEqual(new Set(["unused", "explicit"]));
+
+    state.globalCounts = { unused: 4 };
+    await act(async () =>
+      root.render(<ReferencePropertyValueInput disabledKeys={disabledKeys} property={property} />),
+    );
+    expect(state.rendererProps!.disabledKeysSource).toBe(source);
+    expect(source.getSnapshot()).toEqual(new Set(["explicit"]));
+    expect(listener).toHaveBeenCalledTimes(1);
+    unsubscribe();
+  });
+
+  it("hides zero badges while keeping positive badges", async () => {
+    await act(async () =>
+      root.render(
+        <>
+          <ReferenceValueCount count={0} />
+          <ReferenceValueCount />
+          <ReferenceValueCount count={3} />
+        </>,
+      ),
+    );
+    expect(container.textContent).toBe("(3)");
+    expect(container.querySelectorAll("span")).toHaveLength(1);
+  });
+
+  it("hides zero in settings and disables its empty resource search without affecting used values", async () => {
+    state.globalCounts = { unused: 0, used: 5 };
+    await act(async () =>
+      root.render(
+        <ReferenceValueUsageProvider
+          options={{ choices: [{ value: "unused" }, { value: "used" }] }}
+          property={property}
+        >
+          <ReferenceValueUsage value="unused" />
+          <ReferenceValueUsage value="used" />
+        </ReferenceValueUsageProvider>,
+      ),
+    );
+    const buttons = [...container.querySelectorAll("button")];
+
+    expect(buttons[0].disabled).toBe(true);
+    expect(buttons[1].disabled).toBe(false);
+    expect(container.textContent).not.toContain("0");
+    expect(container.textContent).toContain("5");
+    await act(async () => {
+      buttons[0].click();
+    });
+    expect(state.createPortal).not.toHaveBeenCalled();
+  });
+
+  it("keeps saved values searchable while counts load, but disallows draft option searches", async () => {
+    await act(async () =>
+      root.render(
+        <ReferenceValueUsageProvider
+          options={{ choices: [{ value: "saved" }] }}
+          property={property}
+        >
+          <ReferenceValueUsage value="saved" />
+          <ReferenceValueUsage value="draft" />
+        </ReferenceValueUsageProvider>,
+      ),
+    );
+    const buttons = [...container.querySelectorAll("button")];
+
+    expect(buttons[0].disabled).toBe(false);
+    expect(buttons[1].disabled).toBe(true);
+  });
+});

--- a/src/web/src/components/Property/components/PropertyValueRenderer.tsx
+++ b/src/web/src/components/Property/components/PropertyValueRenderer.tsx
@@ -1,8 +1,8 @@
 "use client";
 "use strict";
 
+import type { DisabledChoiceKeysSource } from "@/hooks/useDisabledChoiceKeys";
 import type { ResourceCountsSource } from "@/hooks/useResourceCountsSource";
-
 import type { Dayjs } from "dayjs";
 import type { Duration } from "dayjs/plugin/duration";
 import type {
@@ -49,6 +49,9 @@ export type Props = {
   property: IProperty;
   resourceCounts?: Record<string, number>;
   resourceCountsSource?: ResourceCountsSource;
+  /** Reference option IDs that cannot be newly selected; selected values remain removable. */
+  disabledKeys?: ReadonlySet<string>;
+  disabledKeysSource?: DisabledChoiceKeysSource;
   /**
    * Both arguments are serialized (wire-format) strings, not raw values.
    */
@@ -84,6 +87,8 @@ const PropertyValueRenderer = (props: Props) => {
     property,
     resourceCounts,
     resourceCountsSource,
+    disabledKeys,
+    disabledKeysSource,
     variant = "default",
     onValueChange,
     dbValue,
@@ -219,15 +224,17 @@ const PropertyValueRenderer = (props: Props) => {
 
       return (
         <ChoiceValueRenderer
-          resourceCounts={resourceCounts}
-          resourceCountsSource={resourceCountsSource}
           defaultEditing={defaultEditing}
+          disabledKeys={disabledKeys}
+          disabledKeysSource={disabledKeysSource}
           editor={editor}
           getDataSource={async () =>
             choices.map((c) => ({ value: c.value, label: c.label ?? "", color: c.color }))
           }
           isEditing={isEditing}
           isReadonly={isReadonly}
+          resourceCounts={resourceCounts}
+          resourceCountsSource={resourceCountsSource}
           size={size}
           value={typedBv == undefined ? undefined : [typedBv]}
           valueAttributes={vas}
@@ -259,16 +266,18 @@ const PropertyValueRenderer = (props: Props) => {
 
       return (
         <ChoiceValueRenderer
-          resourceCounts={resourceCounts}
-          resourceCountsSource={resourceCountsSource}
           multiple
           defaultEditing={defaultEditing}
+          disabledKeys={disabledKeys}
+          disabledKeysSource={disabledKeysSource}
           editor={simpleEditor}
           getDataSource={async () =>
             choices.map((c) => ({ value: c.value, label: c.label ?? "", color: c.color }))
           }
           isEditing={isEditing}
           isReadonly={isReadonly}
+          resourceCounts={resourceCounts}
+          resourceCountsSource={resourceCountsSource}
           size={size}
           value={typedBv}
           valueAttributes={vas}
@@ -461,14 +470,16 @@ const PropertyValueRenderer = (props: Props) => {
 
       return (
         <MultilevelValueRenderer
-          resourceCounts={resourceCounts}
-          resourceCountsSource={resourceCountsSource}
           defaultEditing={defaultEditing}
+          disabledKeys={disabledKeys}
+          disabledKeysSource={disabledKeysSource}
           editor={simpleEditor}
           getDataSource={async () => data}
           isEditing={isEditing}
           isReadonly={isReadonly}
           multiple={!(options?.valueIsSingleton ?? false)}
+          resourceCounts={resourceCounts}
+          resourceCountsSource={resourceCountsSource}
           size={size}
           value={typedBv}
           valueAttributes={vas}
@@ -500,9 +511,9 @@ const PropertyValueRenderer = (props: Props) => {
 
       return (
         <TagsValueRenderer
-          resourceCounts={resourceCounts}
-          resourceCountsSource={resourceCountsSource}
           defaultEditing={defaultEditing}
+          disabledKeys={disabledKeys}
+          disabledKeysSource={disabledKeysSource}
           editor={simpleEditor}
           getDataSource={async () =>
             tags.map((t) => ({
@@ -514,6 +525,8 @@ const PropertyValueRenderer = (props: Props) => {
           }
           isEditing={isEditing}
           isReadonly={isReadonly}
+          resourceCounts={resourceCounts}
+          resourceCountsSource={resourceCountsSource}
           size={size}
           value={typedBv}
           valueAttributes={vas}

--- a/src/web/src/components/Property/components/ReferenceValueCount.tsx
+++ b/src/web/src/components/Property/components/ReferenceValueCount.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from "react-i18next";
 export default function ReferenceValueCount({ count }: { count?: number }) {
   const { t } = useTranslation();
 
-  if (count === undefined) return null;
+  if (count === undefined || count <= 0) return null;
 
   return (
     <span

--- a/src/web/src/components/Property/referenceValues.ts
+++ b/src/web/src/components/Property/referenceValues.ts
@@ -8,6 +8,15 @@ import { serializeStandardValue } from "@/components/StandardValue/helpers";
 export type ReferenceProperty = Pick<IProperty, "id" | "pool" | "type" | "name">;
 export type ReferenceValueResourceCounts = Record<string, number>;
 
+/** Only explicit global zeros mean an option has no referencing resources. */
+export function getUnreferencedValueIds(
+  counts?: ReferenceValueResourceCounts,
+): ReadonlySet<string> | undefined {
+  return counts === undefined
+    ? undefined
+    : new Set(Object.keys(counts).filter((value) => counts[value] === 0));
+}
+
 /** Use reference IDs, never labels, so case handling stays inside the property module. */
 export function buildReferenceValueSearch(property: ReferenceProperty, value: string): SearchForm {
   const single = property.type === PropertyType.SingleChoice;

--- a/src/web/src/components/PropertyModal/components/ReferenceValueUsage.tsx
+++ b/src/web/src/components/PropertyModal/components/ReferenceValueUsage.tsx
@@ -81,23 +81,29 @@ export default function ReferenceValueUsage({ value, label }: { value: string; l
 
   return (
     <div className="flex shrink-0 items-center gap-1">
-      <span
-        className="text-xs text-default-500 tabular-nums"
-        title={
-          count === undefined
-            ? t("property.reference.countUnavailable")
-            : t("property.reference.resourceCount", { count })
-        }
-      >
-        {count?.toLocaleString() ?? "—"}
-      </span>
+      {count !== 0 && (
+        <span
+          className="text-xs text-default-500 tabular-nums"
+          title={
+            count === undefined
+              ? t("property.reference.countUnavailable")
+              : t("property.reference.resourceCount", { count })
+          }
+        >
+          {count?.toLocaleString() ?? "—"}
+        </span>
+      )}
       <Button
         isIconOnly
         aria-label={t("property.reference.searchResources")}
-        isDisabled={!exists}
+        isDisabled={!exists || count === 0}
         size="sm"
         title={t(
-          exists ? "property.reference.searchResources" : "property.reference.saveBeforeSearch",
+          !exists
+            ? "property.reference.saveBeforeSearch"
+            : count === 0
+              ? "property.reference.noResources"
+              : "property.reference.searchResources",
         )}
         variant="light"
         onPress={() =>

--- a/src/web/src/components/ResourceFilter/components/Filter/ReferencePropertyValueInput.tsx
+++ b/src/web/src/components/ResourceFilter/components/Filter/ReferencePropertyValueInput.tsx
@@ -1,9 +1,17 @@
 import type { Props } from "@/components/Property/components/PropertyValueRenderer";
 
 import { useTranslation } from "react-i18next";
+import { useEffect, useMemo } from "react";
 
 import PropertyValueRenderer from "@/components/Property/components/PropertyValueRenderer";
+import { getUnreferencedValueIds } from "@/components/Property/referenceValues";
+import { createResourceCountsSource } from "@/hooks/useResourceCountsSource";
 import {
+  createDisabledChoiceKeysSource,
+  useDisabledChoiceKeys,
+} from "@/hooks/useDisabledChoiceKeys";
+import {
+  referenceValueCountsCriteria,
   useReferenceValueResourceCounts,
   useReferenceValueSearch,
 } from "@/hooks/useReferenceValueResourceCounts";
@@ -12,7 +20,30 @@ import {
 export default function ReferencePropertyValueInput(props: Props) {
   const { t } = useTranslation();
   const search = useReferenceValueSearch();
-  const { counts, source } = useReferenceValueResourceCounts(props.property, search);
+  // A zero inside the current results can still be a valid replacement/OR choice.
+  // Only global totals decide availability, and remain stable when filters change.
+  const globalUsage = useReferenceValueResourceCounts(props.property);
+  const hasCriteria = JSON.stringify(referenceValueCountsCriteria(search)) !== "{}";
+  const filteredUsage = useReferenceValueResourceCounts(
+    hasCriteria ? props.property : undefined,
+    search,
+  );
+  const { counts } = hasCriteria ? filteredUsage : globalUsage;
+  // Portals keep the original source even when the active criteria become empty/nonempty.
+  const resourceCountsSource = useMemo(createResourceCountsSource, []);
+
+  useEffect(() => resourceCountsSource.publish(counts), [resourceCountsSource, counts]);
+  const explicitDisabledKeys = useDisabledChoiceKeys(props.disabledKeysSource, props.disabledKeys);
+  const disabledKeys = useMemo(() => {
+    const unusedIds = getUnreferencedValueIds(globalUsage.counts);
+
+    if (!unusedIds && !explicitDisabledKeys) return undefined;
+
+    return new Set([...(unusedIds ?? []), ...(explicitDisabledKeys ?? [])]);
+  }, [globalUsage.counts, explicitDisabledKeys]);
+  const disabledKeysSource = useMemo(createDisabledChoiceKeysSource, []);
+
+  useEffect(() => disabledKeysSource.publish(disabledKeys), [disabledKeysSource, disabledKeys]);
 
   return (
     <div
@@ -22,7 +53,13 @@ export default function ReferencePropertyValueInput(props: Props) {
           : undefined
       }
     >
-      <PropertyValueRenderer {...props} resourceCounts={counts} resourceCountsSource={source} />
+      <PropertyValueRenderer
+        {...props}
+        disabledKeys={disabledKeys}
+        disabledKeysSource={disabledKeysSource}
+        resourceCounts={counts}
+        resourceCountsSource={resourceCountsSource}
+      />
     </div>
   );
 }

--- a/src/web/src/components/StandardValue/ValueEditor/Editors/ChoiceValueEditor.tsx
+++ b/src/web/src/components/StandardValue/ValueEditor/Editors/ChoiceValueEditor.tsx
@@ -1,10 +1,5 @@
 "use client";
 
-import {
-  useResourceCountsSource,
-  type ResourceCountsSource,
-} from "@/hooks/useResourceCountsSource";
-
 import type { ValueEditorProps } from "../models";
 import type { DestroyableProps } from "@/components/bakaui/types";
 
@@ -12,6 +7,14 @@ import { useTranslation } from "react-i18next";
 import { useEffect, useState } from "react";
 import { SearchOutlined } from "@ant-design/icons";
 
+import {
+  useResourceCountsSource,
+  type ResourceCountsSource,
+} from "@/hooks/useResourceCountsSource";
+import {
+  useDisabledChoiceKeys,
+  type DisabledChoiceKeysSource,
+} from "@/hooks/useDisabledChoiceKeys";
 import ReferenceValueCount from "@/components/Property/components/ReferenceValueCount";
 import { Button, Input, Modal } from "@/components/bakaui";
 import { buildLogger } from "@/components/utils";
@@ -23,6 +26,8 @@ type ChoiceValueEditorProps = ValueEditorProps<string[] | undefined> &
   DestroyableProps & {
     resourceCounts?: Record<string, number>;
     resourceCountsSource?: ResourceCountsSource;
+    disabledKeys?: ReadonlySet<string>;
+    disabledKeysSource?: DisabledChoiceKeysSource;
     multiple: boolean;
     getDataSource: () => Promise<Data[] | undefined>;
   };
@@ -34,6 +39,8 @@ const ChoiceValueEditor = (props: ChoiceValueEditorProps) => {
   const {
     resourceCounts: initialResourceCounts,
     resourceCountsSource,
+    disabledKeys: initialDisabledKeys,
+    disabledKeysSource,
     multiple,
     getDataSource,
     value: propsValue,
@@ -41,6 +48,7 @@ const ChoiceValueEditor = (props: ChoiceValueEditorProps) => {
   } = props;
 
   const resourceCounts = useResourceCountsSource(resourceCountsSource, initialResourceCounts);
+  const disabledKeys = useDisabledChoiceKeys(disabledKeysSource, initialDisabledKeys);
 
   const [dataSource, setDataSource] = useState<Data[]>([]);
   const [keyword, setKeyword] = useState("");
@@ -101,8 +109,11 @@ const ChoiceValueEditor = (props: ChoiceValueEditorProps) => {
                   <Button
                     key={d.value}
                     color={value.includes(d.value) ? "primary" : "default"}
+                    isDisabled={disabledKeys?.has(d.value) && !value.includes(d.value)}
                     size={"sm"}
                     onClick={() => {
+                      if (disabledKeys?.has(d.value) && !value.includes(d.value)) return;
+
                       if (multiple) {
                         log("value", value, "select", d.value, "includes", value.includes(d.value));
                         if (value.includes(d.value)) {
@@ -111,7 +122,7 @@ const ChoiceValueEditor = (props: ChoiceValueEditorProps) => {
                           setValue([...(value || []), d.value]);
                         }
                       } else {
-                        setValue([d.value]);
+                        setValue(value.includes(d.value) ? [] : [d.value]);
                       }
                     }}
                   >

--- a/src/web/src/components/StandardValue/ValueEditor/Editors/MultilevelValueEditor.tsx
+++ b/src/web/src/components/StandardValue/ValueEditor/Editors/MultilevelValueEditor.tsx
@@ -1,10 +1,5 @@
 "use client";
 
-import {
-  useResourceCountsSource,
-  type ResourceCountsSource,
-} from "@/hooks/useResourceCountsSource";
-
 import type { CSSProperties } from "react";
 import type { ValueEditorProps } from "../models";
 import type { MultilevelData } from "@/components/StandardValue/models";
@@ -15,6 +10,14 @@ import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { RightOutlined, SearchOutlined } from "@ant-design/icons";
 import { useUpdateEffect } from "react-use";
 
+import {
+  useResourceCountsSource,
+  type ResourceCountsSource,
+} from "@/hooks/useResourceCountsSource";
+import {
+  useDisabledChoiceKeys,
+  type DisabledChoiceKeysSource,
+} from "@/hooks/useDisabledChoiceKeys";
 import ReferenceValueCount from "@/components/Property/components/ReferenceValueCount";
 import { Button, Input, Modal } from "@/components/bakaui";
 import {
@@ -33,6 +36,8 @@ interface MultilevelValueEditorProps<V>
   multiple?: boolean;
   resourceCounts?: Record<string, number>;
   resourceCountsSource?: ResourceCountsSource;
+  disabledKeys?: ReadonlySet<string>;
+  disabledKeysSource?: DisabledChoiceKeysSource;
 }
 
 const buildDefaultSelectable: <V>() => Selectable<V> = () => {
@@ -52,9 +57,12 @@ const MultilevelValueEditor = <V = string,>(props: MultilevelValueEditorProps<V>
     multiple,
     resourceCounts: initialResourceCounts,
     resourceCountsSource,
+    disabledKeys: initialDisabledKeys,
+    disabledKeysSource,
   } = props;
 
   const resourceCounts = useResourceCountsSource(resourceCountsSource, initialResourceCounts);
+  const disabledKeys = useDisabledChoiceKeys(disabledKeysSource, initialDisabledKeys);
 
   log(props);
 
@@ -115,6 +123,8 @@ const MultilevelValueEditor = <V = string,>(props: MultilevelValueEditorProps<V>
       // Expand this item - truncate expanded path to this level and add this item
       setExpandedPath([...expandedPath.slice(0, depth), item.value]);
     } else {
+      if (disabledKeys?.has(String(item.value)) && !value.includes(item.value)) return;
+
       // Leaf node - toggle selection
       if (multiple) {
         if (value.includes(item.value)) {
@@ -123,7 +133,7 @@ const MultilevelValueEditor = <V = string,>(props: MultilevelValueEditorProps<V>
           setValue([...value, item.value]);
         }
       } else {
-        setValue([item.value]);
+        setValue(value.includes(item.value) ? [] : [item.value]);
       }
     }
   };
@@ -138,6 +148,8 @@ const MultilevelValueEditor = <V = string,>(props: MultilevelValueEditorProps<V>
           const hasChildren = item.children && item.children.length > 0;
           const isSelected = value.includes(item.value);
           const isExpanded = expandedPath[depth] === item.value;
+          // Parent rows navigate to children; their availability never blocks expansion.
+          const isDisabled = !hasChildren && disabledKeys?.has(String(item.value)) && !isSelected;
           const style: CSSProperties = {};
 
           if (item.color) {
@@ -152,6 +164,7 @@ const MultilevelValueEditor = <V = string,>(props: MultilevelValueEditorProps<V>
               key={idx}
               className="justify-between"
               color={isSelected ? "primary" : isExpanded ? "secondary" : "default"}
+              isDisabled={isDisabled}
               size="sm"
               style={style}
               variant={isExpanded && !isSelected ? "flat" : "solid"}

--- a/src/web/src/components/StandardValue/ValueEditor/Editors/TagsValueEditor.tsx
+++ b/src/web/src/components/StandardValue/ValueEditor/Editors/TagsValueEditor.tsx
@@ -1,10 +1,5 @@
 "use client";
 
-import {
-  useResourceCountsSource,
-  type ResourceCountsSource,
-} from "@/hooks/useResourceCountsSource";
-
 import type { CSSProperties } from "react";
 import type { ValueEditorProps } from "../models";
 import type { TagValue } from "@/components/StandardValue/models";
@@ -14,6 +9,14 @@ import { useTranslation } from "react-i18next";
 import { useEffect, useMemo, useState } from "react";
 import { SearchOutlined } from "@ant-design/icons";
 
+import {
+  useResourceCountsSource,
+  type ResourceCountsSource,
+} from "@/hooks/useResourceCountsSource";
+import {
+  useDisabledChoiceKeys,
+  type DisabledChoiceKeysSource,
+} from "@/hooks/useDisabledChoiceKeys";
 import ReferenceValueCount from "@/components/Property/components/ReferenceValueCount";
 import { Button, Input, Modal } from "@/components/bakaui";
 import { autoBackgroundColor, buildLogger } from "@/components/utils";
@@ -24,6 +27,8 @@ type TagsValueEditorProps = ValueEditorProps<string[], TagValue[]> &
   DestroyableProps & {
     resourceCounts?: Record<string, number>;
     resourceCountsSource?: ResourceCountsSource;
+    disabledKeys?: ReadonlySet<string>;
+    disabledKeysSource?: DisabledChoiceKeysSource;
     getDataSource: () => Promise<TagData[] | undefined>;
   };
 
@@ -34,6 +39,8 @@ const TagsValueEditor = (props: TagsValueEditorProps) => {
   const {
     resourceCounts: initialResourceCounts,
     resourceCountsSource,
+    disabledKeys: initialDisabledKeys,
+    disabledKeysSource,
     getDataSource,
     value: propsValue,
     onValueChange,
@@ -41,6 +48,7 @@ const TagsValueEditor = (props: TagsValueEditorProps) => {
   } = props;
 
   const resourceCounts = useResourceCountsSource(resourceCountsSource, initialResourceCounts);
+  const disabledKeys = useDisabledChoiceKeys(disabledKeysSource, initialDisabledKeys);
 
   const [dataSource, setDataSource] = useState<TagData[]>([]);
   const [keyword, setKeyword] = useState("");
@@ -89,6 +97,8 @@ const TagsValueEditor = (props: TagsValueEditorProps) => {
   }, [dataSource, keyword]);
 
   const toggleTag = (tagValue: string) => {
+    if (disabledKeys?.has(tagValue) && !value.includes(tagValue)) return;
+
     if (value.includes(tagValue)) {
       setValue(value.filter((v) => v !== tagValue));
     } else {
@@ -111,6 +121,7 @@ const TagsValueEditor = (props: TagsValueEditorProps) => {
       <Button
         key={tag.value}
         color={isSelected ? "primary" : "default"}
+        isDisabled={disabledKeys?.has(tag.value) && !isSelected}
         size={"sm"}
         style={style}
         onPress={() => toggleTag(tag.value)}

--- a/src/web/src/components/StandardValue/ValueRenderer/Renderers/ChoiceValueRenderer.tsx
+++ b/src/web/src/components/StandardValue/ValueRenderer/Renderers/ChoiceValueRenderer.tsx
@@ -2,7 +2,6 @@
 "use strict";
 
 import type { ResourceCountsSource } from "@/hooks/useResourceCountsSource";
-
 import type { ValueRendererProps } from "../models";
 
 import { useEffect, useState, useMemo, useRef } from "react";
@@ -14,6 +13,10 @@ import { buildVisibleOptions, hasMoreOptions, getRemainingCount } from "../utils
 import NotSet, { LightText } from "./components/LightText";
 import NoChoicesAvailable from "./components/NoChoicesAvailable";
 
+import {
+  useDisabledChoiceKeys,
+  type DisabledChoiceKeysSource,
+} from "@/hooks/useDisabledChoiceKeys";
 import SelectableChip from "@/components/StandardValue/ValueRenderer/Renderers/components/SelectableChip";
 import { useBakabaseContext } from "@/components/ContextProvider/BakabaseContextProvider";
 import { Button } from "@/components/bakaui";
@@ -36,6 +39,8 @@ type ChoiceValueRendererProps = ValueRendererProps<string[], string[]> & {
   size?: "sm" | "md" | "lg";
   resourceCounts?: Record<string, number>;
   resourceCountsSource?: ResourceCountsSource;
+  disabledKeys?: ReadonlySet<string>;
+  disabledKeysSource?: DisabledChoiceKeysSource;
 };
 
 const log = buildLogger("ChoiceValueRenderer");
@@ -49,6 +54,8 @@ const ChoiceValueRenderer = (props: ChoiceValueRendererProps) => {
     valueAttributes,
     resourceCounts,
     resourceCountsSource,
+    disabledKeys: initialDisabledKeys,
+    disabledKeysSource,
     size,
     isReadonly: propsIsReadonly,
     isEditing: controlledIsEditing,
@@ -59,6 +66,7 @@ const ChoiceValueRenderer = (props: ChoiceValueRendererProps) => {
   const [dataSource, setDataSource] = useState<Data[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [optionsThreshold] = useFilterOptionsThreshold();
+  const disabledKeys = useDisabledChoiceKeys(disabledKeysSource, initialDisabledKeys);
 
   // Internal editing state for uncontrolled mode
   const [internalIsEditing, setInternalIsEditing] = useState(defaultEditing);
@@ -109,6 +117,8 @@ const ChoiceValueRenderer = (props: ChoiceValueRendererProps) => {
         createPortal(ChoiceValueEditor, {
           resourceCounts,
           resourceCountsSource,
+          disabledKeys,
+          disabledKeysSource,
           value: editor?.value,
           getDataSource: getDataSource ?? (async () => []),
           onValueChange: editor?.onValueChange,
@@ -127,6 +137,7 @@ const ChoiceValueRenderer = (props: ChoiceValueRendererProps) => {
 
   const toggleValue = (itemValue: string) => {
     if (isReadonly || !editor?.onValueChange) return;
+    if (disabledKeys?.has(itemValue) && !selectedValues.includes(itemValue)) return;
 
     if (multiple) {
       const newDbValues = selectedValues.includes(itemValue)
@@ -182,6 +193,7 @@ const ChoiceValueRenderer = (props: ChoiceValueRendererProps) => {
           <SelectableChip
             key={item.value}
             color={item.color}
+            isDisabled={disabledKeys?.has(item.value) && !selectedValues.includes(item.value)}
             isSelected={selectedValues.includes(item.value)}
             itemKey={item.value}
             label={

--- a/src/web/src/components/StandardValue/ValueRenderer/Renderers/MultilevelValueRenderer.tsx
+++ b/src/web/src/components/StandardValue/ValueRenderer/Renderers/MultilevelValueRenderer.tsx
@@ -2,7 +2,6 @@
 "use strict";
 
 import type { ResourceCountsSource } from "@/hooks/useResourceCountsSource";
-
 import type { ValueRendererProps } from "../models";
 import type { MultilevelData } from "../../models";
 
@@ -12,6 +11,10 @@ import { useTranslation } from "react-i18next";
 import MultilevelValueEditor from "../../ValueEditor/Editors/MultilevelValueEditor";
 import { buildVisibleOptions, hasMoreOptions, getRemainingCount } from "../utils";
 
+import {
+  useDisabledChoiceKeys,
+  type DisabledChoiceKeysSource,
+} from "@/hooks/useDisabledChoiceKeys";
 import { useBakabaseContext } from "@/components/ContextProvider/BakabaseContextProvider";
 import { Button } from "@/components/bakaui";
 import NotSet, {
@@ -36,6 +39,8 @@ type MultilevelValueRendererProps = ValueRendererProps<string[][], string[]> & {
   size?: "sm" | "md" | "lg";
   resourceCounts?: Record<string, number>;
   resourceCountsSource?: ResourceCountsSource;
+  disabledKeys?: ReadonlySet<string>;
+  disabledKeysSource?: DisabledChoiceKeysSource;
 };
 
 const log = buildLogger("MultilevelValueRenderer");
@@ -50,6 +55,8 @@ const MultilevelValueRenderer = ({
   valueAttributes,
   resourceCounts,
   resourceCountsSource,
+  disabledKeys: initialDisabledKeys,
+  disabledKeysSource,
   size,
   isReadonly: propsIsReadonly,
   isEditing: controlledIsEditing,
@@ -59,6 +66,7 @@ const MultilevelValueRenderer = ({
   const [dataSource, setDataSource] = useState<MultilevelData<string>[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [optionsThreshold] = useFilterOptionsThreshold();
+  const disabledKeys = useDisabledChoiceKeys(disabledKeysSource, initialDisabledKeys);
 
   // Internal editing state for uncontrolled mode
   const [internalIsEditing, setInternalIsEditing] = useState(defaultEditing);
@@ -107,6 +115,8 @@ const MultilevelValueRenderer = ({
         createPortal(MultilevelValueEditor<string>, {
           resourceCounts,
           resourceCountsSource,
+          disabledKeys,
+          disabledKeysSource,
           getDataSource: getDataSource,
           onValueChange: editor?.onValueChange,
           multiple,
@@ -163,6 +173,8 @@ const MultilevelValueRenderer = ({
     const leafValue = path[path.length - 1];
     const isSelected = selectedValues.includes(leafValue);
 
+    if (disabledKeys?.has(leafValue) && !isSelected) return;
+
     let newDbValues: string[];
     let newBizValues: string[][];
 
@@ -209,6 +221,9 @@ const MultilevelValueRenderer = ({
           <SelectableChip
             key={opt.path.join("/")}
             color={opt.color}
+            isDisabled={
+              disabledKeys?.has(opt.path[opt.path.length - 1]) && !isPathSelected(opt.path)
+            }
             isSelected={isPathSelected(opt.path)}
             itemKey={opt.path.join("/")}
             label={

--- a/src/web/src/components/StandardValue/ValueRenderer/Renderers/TagsValueRenderer.tsx
+++ b/src/web/src/components/StandardValue/ValueRenderer/Renderers/TagsValueRenderer.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import type { ResourceCountsSource } from "@/hooks/useResourceCountsSource";
-
 import type { ValueRendererProps } from "../models";
 import type { TagValue } from "../../models";
 
@@ -14,6 +13,10 @@ import { buildVisibleOptions, hasMoreOptions, getRemainingCount } from "../utils
 import NotSet, { LightText } from "./components/LightText";
 import NoChoicesAvailable from "./components/NoChoicesAvailable";
 
+import {
+  useDisabledChoiceKeys,
+  type DisabledChoiceKeysSource,
+} from "@/hooks/useDisabledChoiceKeys";
 import SelectableChip from "@/components/StandardValue/ValueRenderer/Renderers/components/SelectableChip";
 import { useBakabaseContext } from "@/components/ContextProvider/BakabaseContextProvider";
 import { Button } from "@/components/bakaui";
@@ -29,6 +32,8 @@ type TagsValueRendererProps = ValueRendererProps<TagValue[], string[]> & {
   size?: "sm" | "md" | "lg";
   resourceCounts?: Record<string, number>;
   resourceCountsSource?: ResourceCountsSource;
+  disabledKeys?: ReadonlySet<string>;
+  disabledKeysSource?: DisabledChoiceKeysSource;
 };
 
 const log = buildLogger("TagsValueRenderer");
@@ -44,6 +49,8 @@ const TagsValueRenderer = (props: TagsValueRendererProps) => {
     valueAttributes,
     resourceCounts,
     resourceCountsSource,
+    disabledKeys: initialDisabledKeys,
+    disabledKeysSource,
     size,
     isReadonly: propsIsReadonly,
     isEditing: controlledIsEditing,
@@ -52,6 +59,7 @@ const TagsValueRenderer = (props: TagsValueRendererProps) => {
   const [dataSource, setDataSource] = useState<TagData[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [optionsThreshold] = useFilterOptionsThreshold();
+  const disabledKeys = useDisabledChoiceKeys(disabledKeysSource, initialDisabledKeys);
 
   // Internal editing state for uncontrolled mode
   const [internalIsEditing, setInternalIsEditing] = useState(defaultEditing);
@@ -110,6 +118,8 @@ const TagsValueRenderer = (props: TagsValueRendererProps) => {
         createPortal(TagsValueEditor, {
           resourceCounts,
           resourceCountsSource,
+          disabledKeys,
+          disabledKeysSource,
           value: editor?.value,
           getDataSource: async () => {
             return (await getDataSource?.()) || [];
@@ -125,6 +135,7 @@ const TagsValueRenderer = (props: TagsValueRendererProps) => {
 
   const toggleValue = (tagValue: string) => {
     if (isReadonly || !editor?.onValueChange) return;
+    if (disabledKeys?.has(tagValue) && !selectedValues.includes(tagValue)) return;
 
     const tag = dataSource.find((t) => t.value === tagValue);
 
@@ -171,6 +182,7 @@ const TagsValueRenderer = (props: TagsValueRendererProps) => {
           <SelectableChip
             key={item.value}
             color={item.color}
+            isDisabled={disabledKeys?.has(item.value) && !selectedValues.includes(item.value)}
             isSelected={selectedValues.includes(item.value)}
             itemKey={item.value}
             label={

--- a/src/web/src/components/StandardValue/__tests__/disabledChoices.test.tsx
+++ b/src/web/src/components/StandardValue/__tests__/disabledChoices.test.tsx
@@ -1,0 +1,305 @@
+import type { ComponentType, ReactNode } from "react";
+import type { DisabledChoiceKeysSource } from "@/hooks/useDisabledChoiceKeys";
+
+import { createElement } from "react";
+import { createRoot } from "react-dom/client";
+import { act } from "react-dom/test-utils";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import ChoiceValueRenderer from "../ValueRenderer/Renderers/ChoiceValueRenderer";
+import TagsValueRenderer from "../ValueRenderer/Renderers/TagsValueRenderer";
+import MultilevelValueRenderer from "../ValueRenderer/Renderers/MultilevelValueRenderer";
+import MultilevelValueEditor from "../ValueEditor/Editors/MultilevelValueEditor";
+
+import { createDisabledChoiceKeysSource } from "@/hooks/useDisabledChoiceKeys";
+
+const { createPortal, optionsThreshold } = vi.hoisted(() => ({
+  createPortal: vi.fn(),
+  optionsThreshold: { current: 30 },
+}));
+
+vi.mock("@/components/ContextProvider/BakabaseContextProvider", () => ({
+  useBakabaseContext: () => ({ createPortal }),
+}));
+vi.mock("@/hooks/useFilterOptionsThreshold", () => ({
+  DEFAULT_FILTER_OPTIONS_THRESHOLD: 30,
+  getFilterOptionsThreshold: () => optionsThreshold.current,
+  useFilterOptionsThreshold: () => [optionsThreshold.current],
+}));
+vi.mock("@/components/utils", () => ({
+  buildLogger: () => () => {},
+  autoBackgroundColor: (color: string) => color,
+}));
+vi.mock("@/components/bakaui", () => {
+  const Button = ({
+    children,
+    isDisabled,
+    onClick,
+    onPress,
+  }: {
+    children?: ReactNode;
+    isDisabled?: boolean;
+    onClick?: () => void;
+    onPress?: () => void;
+  }) => (
+    <button disabled={isDisabled} type="button" onClick={onClick ?? onPress}>
+      {children}
+    </button>
+  );
+
+  return {
+    Button,
+    Chip: Button,
+    Input: ({
+      placeholder,
+      value,
+      onValueChange,
+    }: {
+      placeholder?: string;
+      value?: string;
+      onValueChange?: (value: string) => void;
+    }) => (
+      <input
+        placeholder={placeholder}
+        value={value}
+        onChange={(event) => onValueChange?.(event.target.value)}
+      />
+    ),
+    Modal: ({ children, onOk }: { children?: ReactNode; onOk?: () => void }) => (
+      <div aria-label="Select data" role="dialog">
+        {children}
+        <button type="button" onClick={onOk}>
+          Apply
+        </button>
+      </div>
+    ),
+  };
+});
+
+type ScenarioProps = {
+  selected?: string[];
+  disabledKeys?: ReadonlySet<string>;
+  disabledKeysSource?: DisabledChoiceKeysSource;
+  onValueChange: ReturnType<typeof vi.fn>;
+};
+
+const choices = [
+  { value: "unused-id", label: "Unused" },
+  { value: "used-id", label: "Used" },
+];
+const getChoices = async () => choices;
+const getTags = async () => choices.map(({ value, label }) => ({ value, name: label }));
+
+const scenarios = [
+  ...[false, true].map((multiple) => ({
+    name: multiple ? "multiple choices" : "single choice",
+    render: ({ selected, onValueChange, ...disabledProps }: ScenarioProps) => (
+      <ChoiceValueRenderer
+        isEditing
+        editor={{ value: selected, onValueChange }}
+        getDataSource={getChoices}
+        multiple={multiple}
+        {...disabledProps}
+      />
+    ),
+  })),
+  {
+    name: "tags",
+    render: ({ selected, onValueChange, ...disabledProps }: ScenarioProps) => (
+      <TagsValueRenderer
+        isEditing
+        editor={{ value: selected, onValueChange }}
+        getDataSource={getTags}
+        {...disabledProps}
+      />
+    ),
+  },
+  ...[false, true].map((multiple) => ({
+    name: multiple ? "multiple multilevel choices" : "single multilevel choice",
+    render: ({ selected, onValueChange, ...disabledProps }: ScenarioProps) => (
+      <MultilevelValueRenderer
+        isEditing
+        editor={{ value: selected, onValueChange }}
+        getDataSource={getChoices}
+        multiple={multiple}
+        {...disabledProps}
+      />
+    ),
+  })),
+];
+
+const mounted: { root: ReturnType<typeof createRoot>; container: HTMLDivElement }[] = [];
+
+function mount(element: ReactNode) {
+  const container = document.createElement("div");
+
+  document.body.appendChild(container);
+  const root = createRoot(container);
+
+  mounted.push({ root, container });
+  root.render(<>{element}</>);
+}
+
+async function render(element: ReactNode) {
+  await act(async () => mount(element));
+}
+
+function button(name: string | RegExp, container: ParentNode = document) {
+  const result = Array.from(container.querySelectorAll("button")).find((element) => {
+    const label = element.textContent?.trim() ?? "";
+
+    return typeof name === "string" ? label === name : name.test(label);
+  });
+
+  if (!result) throw new Error(`Button not found: ${name}`);
+
+  return result;
+}
+
+async function click(element: HTMLElement) {
+  await act(async () => element.click());
+}
+
+function openedDialog() {
+  const dialog = document.querySelector('[role="dialog"]');
+
+  if (!dialog) throw new Error("Expected the full editor to open");
+
+  return dialog;
+}
+
+beforeEach(() => {
+  (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  optionsThreshold.current = 30;
+  createPortal.mockReset();
+  createPortal.mockImplementation((component: ComponentType, props: Record<string, unknown>) =>
+    mount(createElement(component, props)),
+  );
+});
+
+afterEach(async () => {
+  for (const { root, container } of mounted.splice(0)) {
+    await act(async () => root.unmount());
+    container.remove();
+  }
+});
+
+describe.each(scenarios)("disabled $name", ({ render: renderRenderer }) => {
+  it("blocks unselected disabled choices and allows enabled choices inline", async () => {
+    const onValueChange = vi.fn();
+
+    await render(renderRenderer({ disabledKeys: new Set(["unused-id"]), onValueChange }));
+    const unused = button("Unused");
+
+    expect(unused).toBeDisabled();
+    await click(unused);
+    expect(onValueChange).not.toHaveBeenCalled();
+
+    await click(button("Used"));
+    expect(onValueChange.mock.calls[0][0]).toEqual(["used-id"]);
+  });
+
+  it("allows removing a selected disabled choice inline", async () => {
+    const onValueChange = vi.fn();
+
+    await render(
+      renderRenderer({
+        selected: ["unused-id"],
+        disabledKeys: new Set(["unused-id"]),
+        onValueChange,
+      }),
+    );
+    const unused = button("Unused");
+
+    expect(unused).toBeEnabled();
+    await click(unused);
+    expect(onValueChange).toHaveBeenCalledWith(undefined, undefined);
+  });
+
+  it("keeps an open full editor connected to disabled-key updates", async () => {
+    optionsThreshold.current = 1;
+    const source = createDisabledChoiceKeysSource();
+    const onValueChange = vi.fn();
+
+    await render(renderRenderer({ disabledKeysSource: source, onValueChange }));
+    await click(button(/common.action.more/));
+    const dialog = openedDialog();
+    const unused = button("Unused", dialog);
+
+    expect(unused).toBeEnabled();
+    act(() => source.publish(new Set(["unused-id"])));
+    expect(unused).toBeDisabled();
+    await click(unused);
+    await click(button("Apply", dialog));
+    expect(onValueChange).toHaveBeenLastCalledWith([], []);
+
+    act(() => source.publish(undefined));
+    expect(unused).toBeEnabled();
+    await click(unused);
+    act(() => source.publish(new Set(["unused-id"])));
+    expect(unused).toBeEnabled();
+
+    // A choice that becomes disabled after selection remains removable.
+    await click(unused);
+    expect(unused).toBeDisabled();
+    await click(button("Apply", dialog));
+    expect(onValueChange).toHaveBeenLastCalledWith([], []);
+    expect(createPortal).toHaveBeenCalledTimes(1);
+  });
+
+  it("passes static disabled keys to the full editor and permits removing existing selections", async () => {
+    optionsThreshold.current = 1;
+    const onValueChange = vi.fn();
+
+    await render(
+      renderRenderer({
+        selected: ["unused-id"],
+        disabledKeys: new Set(["unused-id", "used-id"]),
+        onValueChange,
+      }),
+    );
+    await click(button(/common.action.more/));
+    const dialog = openedDialog();
+    const unused = button("Unused", dialog);
+
+    expect(button("Used", dialog)).toBeDisabled();
+    expect(unused).toBeEnabled();
+    await click(unused);
+    expect(unused).toBeDisabled();
+    await click(button("Apply", dialog));
+    expect(onValueChange).toHaveBeenCalledWith([], []);
+  });
+});
+
+describe("disabled multilevel navigation", () => {
+  it("expands a disabled parent and selects an enabled descendant", async () => {
+    const onValueChange = vi.fn();
+
+    await render(
+      <MultilevelValueEditor
+        disabledKeys={new Set(["parent-id", "unused-id"])}
+        getDataSource={async () => [{ value: "parent-id", label: "Parent", children: choices }]}
+        onValueChange={onValueChange}
+      />,
+    );
+    const parent = button("Parent");
+
+    expect(parent).toBeEnabled();
+    await click(parent);
+    expect(button("Unused")).toBeDisabled();
+    await click(button("Used"));
+    await click(button("Apply"));
+    expect(onValueChange).toHaveBeenCalledWith(["used-id"], [["Parent", "Used"]]);
+  });
+
+  it("matches disabled keys for numeric multilevel values", async () => {
+    await render(
+      <MultilevelValueEditor<number>
+        disabledKeys={new Set(["42"])}
+        getDataSource={async () => [{ value: 42, label: "Numeric choice" }]}
+      />,
+    );
+
+    expect(button("Numeric choice")).toBeDisabled();
+  });
+});

--- a/src/web/src/hooks/useDisabledChoiceKeys.ts
+++ b/src/web/src/hooks/useDisabledChoiceKeys.ts
@@ -1,0 +1,39 @@
+import { useSyncExternalStore } from "react";
+
+type DisabledKeys = ReadonlySet<string> | undefined;
+
+export type DisabledChoiceKeysSource = {
+  getSnapshot: () => DisabledKeys;
+  subscribe: (listener: () => void) => () => void;
+};
+
+/** Keeps choice availability current in editors mounted in a separate portal. */
+export function createDisabledChoiceKeysSource() {
+  let snapshot: DisabledKeys;
+  const listeners = new Set<() => void>();
+
+  return {
+    getSnapshot: () => snapshot,
+    subscribe: (listener: () => void) => {
+      listeners.add(listener);
+
+      return () => {
+        listeners.delete(listener);
+      };
+    },
+    publish: (keys: DisabledKeys) => {
+      if (keys === snapshot) return;
+      snapshot = keys;
+      listeners.forEach((listener) => listener());
+    },
+  };
+}
+
+const emptySource = createDisabledChoiceKeysSource();
+
+export function useDisabledChoiceKeys(source?: DisabledChoiceKeysSource, fallback?: DisabledKeys) {
+  const current = source ?? emptySource;
+  const keys = useSyncExternalStore(current.subscribe, current.getSnapshot, current.getSnapshot);
+
+  return source ? keys : fallback;
+}

--- a/src/web/src/locales/cn/components/property.json
+++ b/src/web/src/locales/cn/components/property.json
@@ -1,5 +1,5 @@
 {
-  "property.reference.filteredCountsHelp": "括号内为当前筛选结果中引用该值的资源数，随筛选条件更新。",
+  "property.reference.filteredCountsHelp": "括号内为当前筛选结果中引用该值的资源数，零计数不显示。仅全库无资源引用的未选选项会被禁用，已选项仍可取消。",
   "property.reference.ignoreCase": "忽略大小写",
   "property.reference.ignoreCaseHelp": "匹配选项时忽略大小写，并保留首次加入的文本。现有选项及资源引用保持不变；后续传入的文本使用首次匹配的选项。",
   "property.reference.resourceCount": "{{count}} 个资源",

--- a/src/web/src/locales/en/components/property.json
+++ b/src/web/src/locales/en/components/property.json
@@ -1,5 +1,5 @@
 {
-  "property.reference.filteredCountsHelp": "Numbers in parentheses count resources using this value within the current search results and update with the filters.",
+  "property.reference.filteredCountsHelp": "Counts in parentheses show references in the current results; zero counts are hidden. Only unselected values with no references in the library are disabled. Selected values can still be removed.",
   "property.reference.ignoreCase": "Ignore case",
   "property.reference.ignoreCaseHelp": "Match option text without case sensitivity and keep the first spelling added. Existing options and resource references are preserved; incoming text uses the first matching option.",
   "property.reference.resourceCount": "{{count}} resources",


### PR DESCRIPTION
Reference counts of zero now stay hidden, and property configuration disables quick search for values with no resources. Search filters disable unselected values only when their global reference count is zero. For example, choosing A can reduce B's count in the current results to zero while B remains available as a replacement or an OR condition.

Property and standard value renderers/editors now accept optional disabled choice keys and a live source for single choice, multiple choice, tags, and multilevel values. Open dialogs receive count and availability updates; selected values can still be removed, and disabled multilevel parents still allow navigation to available children. Ordinary resource property editing keeps its existing availability.

Validation:
- 48 related frontend tests passed, including 29 new tests for disabled choices, live dialog updates, count visibility, and global versus filtered availability.
- Frontend production build passed.
- Scoped ESLint completed with no errors; TypeScript diagnostics match the existing baseline (347, none added).
- `git diff --check` passed.

Closes #1328
