### PR TITLE
fix(path-mark): restore migrated property mark semantics

### DIFF
--- a/src/abstractions/Bakabase.Abstractions/Extensions/PropertyMarkConfigExtensions.cs
+++ b/src/abstractions/Bakabase.Abstractions/Extensions/PropertyMarkConfigExtensions.cs
@@ -1,0 +1,42 @@
+using Bakabase.Abstractions.Models.Domain;
+using Bakabase.Abstractions.Models.Domain.Constants;
+
+namespace Bakabase.Abstractions.Extensions;
+
+public static class PropertyMarkConfigExtensions
+{
+    /// <summary>
+    /// V220 converted template property locators into property marks whose value-extraction mode
+    /// was stored in <see cref="PropertyMarkConfig.MatchMode"/>, while both applicability selectors
+    /// were left empty. The migrator treated that shape as covering every resource below the mark,
+    /// so runtime consumers must preserve the same meaning for already-migrated databases.
+    /// </summary>
+    public static bool UsesLegacyV220WildcardApplicability(this PropertyMarkConfig config) =>
+        config.ValueType == PropertyValueType.Dynamic &&
+        config.Layer == null &&
+        string.IsNullOrEmpty(config.Regex) &&
+        config.ApplyScope == PathMarkApplyScope.MatchedOnly &&
+        ((config.MatchMode == PathMatchMode.Layer && config.ValueLayer.HasValue) ||
+         (config.MatchMode == PathMatchMode.Regex && !string.IsNullOrEmpty(config.ValueRegex)));
+
+    /// <summary>
+    /// Returns the applicability selector runtime consumers should use without mutating the
+    /// persisted configuration. Explicit modern selectors are returned unchanged.
+    /// </summary>
+    public static (PathMatchMode MatchMode, int? Layer, string? Regex, PathMarkApplyScope ApplyScope)
+        GetEffectiveApplicability(this PropertyMarkConfig config) =>
+        config.UsesLegacyV220WildcardApplicability()
+            ? (PathMatchMode.Layer, 0, null, PathMarkApplyScope.MatchedAndSubdirectories)
+            : (config.MatchMode, config.Layer, config.Regex, config.ApplyScope);
+
+    /// <summary>
+    /// V220 template regex locators matched each resource's path relative to the media-library
+    /// root. The explicit flag is used by corrected migrations; the selectorless shape covers
+    /// databases already converted by the original V220 migrator.
+    /// </summary>
+    public static bool UsesResourceRelativeValueRegex(this PropertyMarkConfig config) =>
+        config.ValueRegexMatchesResourcePath ||
+        (!string.IsNullOrEmpty(config.ValueRegex) &&
+         config.UsesLegacyV220WildcardApplicability() &&
+         config.MatchMode == PathMatchMode.Regex);
+}

--- a/src/abstractions/Bakabase.Abstractions/Models/Domain/PropertyMarkConfig.cs
+++ b/src/abstractions/Bakabase.Abstractions/Models/Domain/PropertyMarkConfig.cs
@@ -67,6 +67,12 @@ public class PropertyMarkConfig
     public string? ValueRegex { get; set; }
 
     /// <summary>
+    /// 是否对每个资源相对于标记路径的路径应用 ValueRegex。
+    /// 仅用于保留 V220 之前媒体库模板中正则属性提取器的语义；新建标记默认为 false。
+    /// </summary>
+    public bool ValueRegexMatchesResourcePath { get; set; }
+
+    /// <summary>
     /// 应用范围
     /// MatchedOnly = 仅对匹配的路径生效
     /// MatchedAndSubdirectories = 对匹配的路径及其所有子目录生效

--- a/src/legacy/Bakabase.InsideWorld.Business/Components/ResourceMove/PathMarkMatchEvaluator.cs
+++ b/src/legacy/Bakabase.InsideWorld.Business/Components/ResourceMove/PathMarkMatchEvaluator.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Text.RegularExpressions;
 using Bakabase.Abstractions.Extensions;
+using Bakabase.Abstractions.Models.Domain;
 using Bakabase.Abstractions.Models.Domain.Constants;
 using Bakabase.InsideWorld.Business.Extensions;
 
@@ -16,6 +17,13 @@ namespace Bakabase.InsideWorld.Business.Components.ResourceMove;
 /// </summary>
 internal static class PathMarkMatchEvaluator
 {
+    public static bool Matches(PropertyMarkConfig config, string markPath, string candidatePath)
+    {
+        var applicability = config.GetEffectiveApplicability();
+        return Matches(applicability.MatchMode, applicability.Layer, applicability.Regex,
+            applicability.ApplyScope, markPath, candidatePath);
+    }
+
     public static bool Matches(PathMatchMode matchMode, int? layer, string? regexPattern,
         PathMarkApplyScope applyScope, string markPath, string candidatePath)
     {

--- a/src/legacy/Bakabase.InsideWorld.Business/Components/ResourceMove/ResourceMoveService.cs
+++ b/src/legacy/Bakabase.InsideWorld.Business/Components/ResourceMove/ResourceMoveService.cs
@@ -560,8 +560,7 @@ public class ResourceMoveService(
                             continue;
                         }
 
-                        effect.WillApply = PathMarkMatchEvaluator.Matches(config.MatchMode, config.Layer,
-                            config.Regex, config.ApplyScope, mark.Path, destPath);
+                        effect.WillApply = PathMarkMatchEvaluator.Matches(config, mark.Path, destPath);
                         effect.PropertyName = mark.Property?.Name;
                         effect.IsDynamic = config.ValueType == PropertyValueType.Dynamic;
                         effect.FixedValue =

--- a/src/legacy/Bakabase.InsideWorld.Business/Services/PathMarkService.cs
+++ b/src/legacy/Bakabase.InsideWorld.Business/Services/PathMarkService.cs
@@ -15,6 +15,9 @@ using Bakabase.Abstractions.Services;
 using Bakabase.InsideWorld.Business.Components.Configurations.Models.Domain;
 using Bakabase.InsideWorld.Business.Components.Gui;
 using Bakabase.Modules.Property.Abstractions.Services;
+using Bakabase.Modules.Property.Extensions;
+using Bakabase.Modules.StandardValue.Abstractions.Services;
+using Bakabase.Modules.StandardValue.Extensions;
 using Bootstrap.Components.Configuration.Abstractions;
 using Bootstrap.Components.DependencyInjection;
 using Bootstrap.Components.Orm;
@@ -521,6 +524,9 @@ public class PathMarkService<TDbContext>(
         object? fixedValue = null;
         int? valueLayer = null;
         string? valueRegex = null;
+        PropertyMarkConfig? propertyConfig = null;
+        CustomProperty? propertyValueDefinition = null;
+        IStandardValueService? propertyValueConverter = null;
 
         switch (request.Type)
         {
@@ -542,14 +548,20 @@ public class PathMarkService<TDbContext>(
                 var config = JsonConvert.DeserializeObject<PropertyMarkConfig>(request.ConfigJson);
                 if (config == null) return results;
 
-                matchMode = config.MatchMode;
-                layer = config.Layer;
-                regex = config.Regex;
-                applyScope = config.ApplyScope;
+                propertyConfig = config;
+                (matchMode, layer, regex, applyScope) = config.GetEffectiveApplicability();
                 valueType = config.ValueType;
                 fixedValue = config.FixedValue;
                 valueLayer = config.ValueLayer;
                 valueRegex = config.ValueRegex;
+                if (config.Pool == PropertyPool.Custom &&
+                    config.UsesResourceRelativeValueRegex() &&
+                    !string.IsNullOrEmpty(config.ValueRegex))
+                {
+                    propertyValueDefinition = await serviceProvider.GetRequiredService<ICustomPropertyService>()
+                        .GetByKey(config.PropertyId);
+                    propertyValueConverter = serviceProvider.GetRequiredService<IStandardValueService>();
+                }
                 break;
             }
             case PathMarkType.MediaLibrary:
@@ -574,6 +586,15 @@ public class PathMarkService<TDbContext>(
         // Step 3: Get matched paths using common logic
         var matchedPaths = GetMatchingPaths(rootPath, matchMode, layer, regex, ct, applyScope, fsTypeFilter,
             extensions);
+        if (request.Type == PathMarkType.Property && matchMode == PathMatchMode.Layer && layer != -1 &&
+            applyScope == PathMarkApplyScope.MatchedAndSubdirectories)
+        {
+            foreach (var match in matchedPaths.Where(Directory.Exists).ToList())
+            {
+                ct.ThrowIfCancellationRequested();
+                matchedPaths.AddRange(GetAllEntries(match, fsTypeFilter, extensions, ct));
+            }
+        }
 
         var rootSegments = rootPath.Split(new[] { Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar },
             StringSplitOptions.RemoveEmptyEntries);
@@ -592,9 +613,14 @@ public class PathMarkService<TDbContext>(
                 (result.ResourceLayerIndex, result.ResourceSegmentName) = CalculateResourceLayerInfo(
                     rootPath, matchedPath, rootSegments, matchedSegments, matchMode, layer, regex);
             }
-            else if (request.Type == PathMarkType.Property || request.Type == PathMarkType.MediaLibrary)
+            else if (request.Type == PathMarkType.Property)
             {
-                // For Property and MediaLibrary: calculate value
+                result.PropertyValue = await CalculatePropertyMarkValue(
+                    rootPath, matchedPath, rootSegments, matchedSegments,
+                    propertyConfig!, propertyValueDefinition, propertyValueConverter);
+            }
+            else if (request.Type == PathMarkType.MediaLibrary)
+            {
                 result.PropertyValue = CalculatePropertyValue(
                     rootPath, matchedPath, rootSegments, matchedSegments,
                     valueType, fixedValue, valueLayer, valueRegex);
@@ -750,7 +776,87 @@ public class PathMarkService<TDbContext>(
     }
 
     /// <summary>
-    /// Calculate property value for Property and MediaLibrary mark types
+    /// Calculate a property-mark value independently from its applicability selector.
+    /// </summary>
+    private async Task<string?> CalculatePropertyMarkValue(
+        string rootPath, string matchedPath, string[] rootSegments, string[] matchedSegments,
+        PropertyMarkConfig config, CustomProperty? customProperty, IStandardValueService? valueConverter)
+    {
+        if (config.ValueType == PropertyValueType.Fixed)
+        {
+            return config.FixedValue?.ToString();
+        }
+
+        if (config.ValueType != PropertyValueType.Dynamic)
+        {
+            return null;
+        }
+
+        if (config.UsesResourceRelativeValueRegex())
+        {
+            if (string.IsNullOrEmpty(config.ValueRegex) || customProperty == null || valueConverter == null)
+            {
+                return null;
+            }
+
+            var relativePath = matchedPath.Length <= rootPath.Length
+                ? string.Empty
+                : matchedPath[rootPath.Length..]
+                    .TrimStart(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+            var values = Regex.Matches(relativePath, config.ValueRegex)
+                .SelectMany(match => match.Groups.Values.Skip(1).Select(group => group.Value))
+                .Where(value => !string.IsNullOrEmpty(value))
+                .Distinct()
+                .ToList();
+            var bizValue = values.Count == 0
+                ? null
+                : await valueConverter.Convert(
+                    values, StandardValueType.ListString, customProperty.Type.GetBizValueType());
+
+            return bizValue?.SerializeAsStandardValue(customProperty.Type.GetBizValueType());
+        }
+
+        // Modern property regex extraction is intentionally mark-relative. It remains independent
+        // from the applicability selector, which may use a layer at the same time.
+        if (!string.IsNullOrEmpty(config.ValueRegex))
+        {
+            var markDirectoryName = Path.GetFileName(rootPath);
+            var regex = new Regex(config.ValueRegex, RegexOptions.IgnoreCase);
+            var match = regex.Match(markDirectoryName);
+            if (match.Success && match.Groups.Count > 1)
+            {
+                return match.Groups[1].Value;
+            }
+            if (match.Success)
+            {
+                return match.Value;
+            }
+
+            return null;
+        }
+
+        if (!config.ValueLayer.HasValue)
+        {
+            return null;
+        }
+
+        var layer = config.ValueLayer.Value;
+        if (layer == 0)
+        {
+            return Path.GetFileName(rootPath);
+        }
+
+        // Positive = forward from root, negative = backward
+        var targetIndex = rootSegments.Length + layer - 1;
+        if (targetIndex >= 0 && targetIndex < matchedSegments.Length)
+        {
+            return matchedSegments[targetIndex];
+        }
+        return null;
+    }
+
+    /// <summary>
+    /// Calculate media-library mark values using the existing extraction semantics.
     /// </summary>
     private string? CalculatePropertyValue(
         string rootPath, string matchedPath, string[] rootSegments, string[] matchedSegments,

--- a/src/legacy/Bakabase.InsideWorld.Business/Services/PathMarkSyncService.cs
+++ b/src/legacy/Bakabase.InsideWorld.Business/Services/PathMarkSyncService.cs
@@ -21,6 +21,7 @@ using Bakabase.Modules.Property.Abstractions.Models.Db;
 using Bakabase.Modules.Property.Abstractions.Services;
 using Bakabase.Modules.Property.Extensions;
 using Bakabase.Modules.StandardValue;
+using Bakabase.Modules.StandardValue.Abstractions.Services;
 using Bakabase.Modules.StandardValue.Extensions;
 using Bootstrap.Components.Configuration.Abstractions;
 using CustomProperty = Bakabase.Abstractions.Models.Domain.CustomProperty;
@@ -52,6 +53,7 @@ public class PathMarkSyncService : ScopedService
     private readonly IMediaLibraryV2Service _mediaLibraryV2Service;
     private readonly ICustomPropertyValueService _customPropertyValueService;
     private readonly ICustomPropertyService _customPropertyService;
+    private readonly IStandardValueService _standardValueService;
     private readonly IPathMarkEffectService _effectService;
     private readonly IResourceSourceLinkService _sourceLinkService;
     private readonly IBakabaseLocalizer _localizer;
@@ -66,6 +68,7 @@ public class PathMarkSyncService : ScopedService
         IMediaLibraryV2Service mediaLibraryV2Service,
         ICustomPropertyValueService customPropertyValueService,
         ICustomPropertyService customPropertyService,
+        IStandardValueService standardValueService,
         IPathMarkEffectService effectService,
         IResourceSourceLinkService sourceLinkService,
         IBakabaseLocalizer localizer,
@@ -78,6 +81,7 @@ public class PathMarkSyncService : ScopedService
         _mediaLibraryV2Service = mediaLibraryV2Service;
         _customPropertyValueService = customPropertyValueService;
         _customPropertyService = customPropertyService;
+        _standardValueService = standardValueService;
         _effectService = effectService;
         _sourceLinkService = sourceLinkService;
         _localizer = localizer;
@@ -335,40 +339,56 @@ public class PathMarkSyncService : ScopedService
     /// <summary>
     /// Collects property effects from a mark WITHOUT setting any property values.
     /// </summary>
-    private Task CollectPropertyEffects(PathMark mark, SyncContext ctx, CancellationToken ct)
+    private async Task CollectPropertyEffects(PathMark mark, SyncContext ctx, CancellationToken ct)
     {
         var config = JsonConvert.DeserializeObject<PropertyMarkConfig>(mark.ConfigJson);
-        if (config == null) return Task.CompletedTask;
+        if (config == null) return;
 
         // Only support Custom properties for now
-        if (config.Pool != PropertyPool.Custom) return Task.CompletedTask;
+        if (config.Pool != PropertyPool.Custom) return;
+
+        if (config.ValueType == PropertyValueType.Dynamic &&
+            ((config.ValueRegexMatchesResourcePath && string.IsNullOrEmpty(config.ValueRegex)) ||
+             (string.IsNullOrEmpty(config.ValueRegex) && !config.ValueLayer.HasValue)))
+        {
+            // An incomplete regex extractor must never silently turn into layer 0. Besides being
+            // surprising for modern marks, that fallback could overwrite an entire migrated tree.
+            return;
+        }
+
+        // V220 regex locators operated on each resource-relative path and converted all
+        // capture groups to the target property's business value type.
+        CustomProperty? valueProperty = null;
+        if (config.UsesResourceRelativeValueRegex())
+        {
+            valueProperty = await _customPropertyService.GetByKey(config.PropertyId);
+        }
 
         // Use cached resources - match ALL resources under this mark's path
         var matchedResources = ctx.AllResources
             .Where(r => ctx.IsPathUnderParent(r.Path, mark.Path))
             .ToList();
 
-        if (matchedResources.Count == 0) return Task.CompletedTask;
+        if (matchedResources.Count == 0) return;
 
         var filteredResources = FilterResourcesByMarkConfig(matchedResources, mark.Path, config, ctx);
-        if (filteredResources.Count == 0) return Task.CompletedTask;
+        if (filteredResources.Count == 0) return;
 
         var valueType = config.ValueType;
-        var valueLayer = config.ValueLayer;
-        var needsPerResourceExtraction =
-            valueType == PropertyValueType.Dynamic && valueLayer.HasValue && valueLayer.Value > 0;
+        var needsPerResourceExtraction = valueType == PropertyValueType.Dynamic &&
+                                         PropertyDynamicValueDependsOnResource(config);
 
         // For fixed values or dynamic values with valueLayer <= 0, extract once
         object? sharedValue = null;
         if (valueType == PropertyValueType.Fixed)
         {
             sharedValue = config.FixedValue;
-            if (sharedValue == null) return Task.CompletedTask;
+            if (sharedValue == null) return;
         }
         else if (!needsPerResourceExtraction)
         {
-            sharedValue = ExtractDynamicValue(mark.Path, null, config.MatchMode, valueLayer, config.ValueRegex, ctx);
-            if (sharedValue == null) return Task.CompletedTask;
+            sharedValue = ExtractPropertyDynamicValue(mark.Path, null, config, valueProperty, ctx);
+            if (sharedValue == null) return;
         }
 
         foreach (var resource in filteredResources)
@@ -378,8 +398,10 @@ public class PathMarkSyncService : ScopedService
             object? value;
             if (needsPerResourceExtraction)
             {
-                value = ExtractDynamicValue(mark.Path, resource.Path, config.MatchMode, valueLayer, config.ValueRegex,
-                    ctx);
+                value = config.UsesResourceRelativeValueRegex()
+                    ? await ExtractResourceRelativeRegexValueAsync(
+                        mark.Path, resource.Path, config.ValueRegex!, valueProperty!, ctx)
+                    : ExtractPropertyDynamicValue(mark.Path, resource.Path, config, valueProperty, ctx);
                 if (value == null) continue;
             }
             else
@@ -402,7 +424,6 @@ public class PathMarkSyncService : ScopedService
             ctx.CurrentPropertyEffectKeys.Add((mark.Id, config.Pool, config.PropertyId, resource.Id));
         }
 
-        return Task.CompletedTask;
     }
 
     /// <summary>
@@ -709,7 +730,7 @@ public class PathMarkSyncService : ScopedService
             // This is the same applicability/extraction path used by CollectPropertyEffects.
             // If it succeeds there is no representation guess: persist exactly what a fresh
             // collection would have produced.
-            if (TryExtractCurrentBusinessValue(effect, ctx, out var extractedBizValue))
+            if (TryExtractCurrentBusinessValue(effect, customProperty, ctx, out var extractedBizValue))
             {
                 if (effect.Value != extractedBizValue)
                 {
@@ -751,6 +772,7 @@ public class PathMarkSyncService : ScopedService
     /// </summary>
     private bool TryExtractCurrentBusinessValue(
         PropertyMarkEffect effect,
+        CustomProperty customProperty,
         SyncContext ctx,
         out string businessValue)
     {
@@ -786,9 +808,10 @@ public class PathMarkSyncService : ScopedService
             }
             else
             {
-                var resourcePath = config.ValueLayer is > 0 ? resource.Path : null;
-                extractedValue = ExtractDynamicValue(mark.Path, resourcePath, config.MatchMode,
-                    config.ValueLayer, config.ValueRegex, ctx);
+                var resourcePath = PropertyDynamicValueDependsOnResource(config)
+                    ? resource.Path
+                    : null;
+                extractedValue = ExtractPropertyDynamicValue(mark.Path, resourcePath, config, customProperty, ctx);
             }
 
             if (extractedValue == null)
@@ -1190,7 +1213,96 @@ public class PathMarkSyncService : ScopedService
     }
 
     /// <summary>
-    /// Unified dynamic value extraction method for both Property and MediaLibrary marks.
+    /// Positive layer extraction and legacy resource-relative regex extraction need the concrete
+    /// resource path; mark-relative layers and modern regex extraction are shared by every resource.
+    /// </summary>
+    private static bool PropertyDynamicValueDependsOnResource(PropertyMarkConfig config) =>
+        config.UsesResourceRelativeValueRegex() ||
+        (string.IsNullOrEmpty(config.ValueRegex) && config.ValueLayer is > 0);
+
+    /// <summary>
+    /// Property value extraction has its own selector. It must not inherit the applicability
+    /// MatchMode: a property may cover resources by layer while extracting a regex capture,
+    /// which is also the explicit shape emitted by the corrected V220 converter.
+    /// </summary>
+    private object? ExtractPropertyDynamicValue(
+        string markPath,
+        string? resourcePath,
+        PropertyMarkConfig config,
+        CustomProperty? customProperty,
+        SyncContext ctx) =>
+        config.UsesResourceRelativeValueRegex()
+            ? string.IsNullOrEmpty(config.ValueRegex) || customProperty == null
+                ? null
+                : ExtractResourceRelativeRegexValue(markPath, resourcePath, config.ValueRegex, customProperty, ctx)
+            : !string.IsNullOrEmpty(config.ValueRegex)
+                ? ExtractMarkDirectoryRegexValue(markPath, config.ValueRegex, ctx)
+                : config.ValueLayer.HasValue
+                    ? ExtractDynamicValue(markPath, resourcePath, PathMatchMode.Layer, config.ValueLayer, null, ctx)
+                    : null;
+
+    private static object? ExtractResourceRelativeRegexValue(
+        string markPath,
+        string? resourcePath,
+        string valueRegex,
+        CustomProperty customProperty,
+        SyncContext ctx)
+    {
+        var values = ExtractResourceRelativeRegexCaptures(markPath, resourcePath, valueRegex, ctx);
+
+        if (values.Count == 0) return null;
+
+        var bizValueType = customProperty.Type.GetBizValueType();
+        return StandardValueSystem.Convert(values, StandardValueType.ListString, bizValueType)
+            ?.SerializeAsStandardValue(bizValueType);
+    }
+
+    private async Task<object?> ExtractResourceRelativeRegexValueAsync(
+        string markPath,
+        string? resourcePath,
+        string valueRegex,
+        CustomProperty customProperty,
+        SyncContext ctx)
+    {
+        var values = ExtractResourceRelativeRegexCaptures(markPath, resourcePath, valueRegex, ctx);
+        if (values.Count == 0) return null;
+
+        var bizValueType = customProperty.Type.GetBizValueType();
+        return (await _standardValueService.Convert(values, StandardValueType.ListString, bizValueType))
+            ?.SerializeAsStandardValue(bizValueType);
+    }
+
+    private static List<string> ExtractResourceRelativeRegexCaptures(
+        string markPath,
+        string? resourcePath,
+        string valueRegex,
+        SyncContext ctx)
+    {
+        if (string.IsNullOrEmpty(resourcePath)) return [];
+
+        var normalizedMarkPath = ctx.GetStandardizedPath(markPath);
+        var normalizedResourcePath = ctx.GetStandardizedPath(resourcePath);
+        var relativePath = normalizedResourcePath.Length <= normalizedMarkPath.Length
+            ? string.Empty
+            : normalizedResourcePath[normalizedMarkPath.Length..]
+                .TrimStart(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        return Regex.Matches(relativePath, valueRegex)
+            .SelectMany(match => match.Groups.Values.Skip(1).Select(group => group.Value))
+            .Where(value => !string.IsNullOrEmpty(value))
+            .Distinct()
+            .ToList();
+    }
+
+    private static string? ExtractMarkDirectoryRegexValue(string markPath, string valueRegex, SyncContext ctx)
+    {
+        var markDirectoryName = Path.GetFileName(ctx.GetStandardizedPath(markPath));
+        var match = ctx.GetOrCreateRegex(valueRegex).Match(markDirectoryName);
+        return match.Success ? match.Groups.Count > 1 ? match.Groups[1].Value : match.Value : null;
+    }
+
+    /// <summary>
+    /// Low-level extractor retained for media-library marks, whose existing behavior selects
+    /// the extraction strategy through their applicability MatchMode.
     /// </summary>
     private string? ExtractDynamicValue(
         string markPath,
@@ -1355,10 +1467,7 @@ public class PathMarkSyncService : ScopedService
 
         if (config is PropertyMarkConfig pmc)
         {
-            matchMode = pmc.MatchMode;
-            layer = pmc.Layer;
-            regex = pmc.Regex;
-            applyScope = pmc.ApplyScope;
+            (matchMode, layer, regex, applyScope) = pmc.GetEffectiveApplicability();
         }
         else if (config is MediaLibraryMarkConfig mlmc)
         {

--- a/src/legacy/Bakabase.InsideWorld.Business/Services/PathMarkSyncService.cs
+++ b/src/legacy/Bakabase.InsideWorld.Business/Services/PathMarkSyncService.cs
@@ -300,10 +300,13 @@ public class PathMarkSyncService : ScopedService
             await PersistEffects(ctx);
 
             // ===== Cleanup (95-100%) =====
+            // Property and mapping writes enqueue background index reads through a separate
+            // DbContext. Drain those reads before writing mark statuses so SQLite does not see
+            // a reader/writer race, and only report the marks as synced once search is current.
+            await _resourceSearchIndexService.WaitForPendingUpdatesAsync(ct);
+
             await ReportProgress(onProgressChange, onProcessChange, 95, "Updating mark statuses...");
             await BatchUpdateMarkStatuses(ctx, marksToDelete);
-
-            await _resourceSearchIndexService.WaitForPendingUpdatesAsync(ct);
 
             await ReportProgress(onProgressChange, onProcessChange, 100, _localizer.SyncPathMark_Complete());
         }

--- a/src/legacy/Bakabase.Migrations/V220/V220Migrator.cs
+++ b/src/legacy/Bakabase.Migrations/V220/V220Migrator.cs
@@ -514,8 +514,7 @@ public class V220Migrator : AbstractMigrator
                     // - BasePathType.Resource: CANNOT migrate (was purely resource-based)
 
                     int? valueLayer = null;
-                    string? valueRegex = locator.Regex;
-                    var matchMode = PathMatchMode.Regex;
+                    string? valueRegex = null;
 
                     if (locator.Positioner == PathPositioner.Layer && locator.Layer.HasValue)
                     {
@@ -526,7 +525,6 @@ public class V220Migrator : AbstractMigrator
                             // Layer < 0: go UP (parent directories)
                             // Layer > 0: go DOWN (child directories, extracted using resource path)
                             valueLayer = locator.Layer.Value;
-                            matchMode = PathMatchMode.Layer;
                         }
                         else // Resource base
                         {
@@ -541,8 +539,9 @@ public class V220Migrator : AbstractMigrator
                     }
                     else if (locator.Positioner == PathPositioner.Regex && !string.IsNullOrEmpty(locator.Regex))
                     {
-                        // Regex mode: apply regex on mark path's directory name
-                        matchMode = PathMatchMode.Regex;
+                        // Legacy template regexes matched every resource's path relative to the
+                        // media-library root, not the mark directory name.
+                        valueRegex = locator.Regex;
                     }
                     else
                     {
@@ -555,12 +554,16 @@ public class V220Migrator : AbstractMigrator
                         Pool = prop.Pool,
                         PropertyId = prop.Id,
                         ValueType = PropertyValueType.Dynamic,
-                        MatchMode = matchMode,
-                        Layer = null,
-                        Regex = null, // Null regex matches all paths
+                        // Template properties applied to every resource in the media library path.
+                        // Persist that applicability explicitly; value extraction is configured
+                        // independently through ValueLayer / ValueRegex below.
+                        MatchMode = PathMatchMode.Layer,
+                        Layer = 0,
+                        Regex = null,
                         ValueLayer = valueLayer,
                         ValueRegex = valueRegex,
-                        ApplyScope = PathMarkApplyScope.MatchedOnly
+                        ValueRegexMatchesResourcePath = !string.IsNullOrEmpty(valueRegex),
+                        ApplyScope = PathMarkApplyScope.MatchedAndSubdirectories
                     };
                     marks.Add(new PathMark
                     {

--- a/src/tests/Bakabase.Tests/PathMarkReferenceValueRegressionTests.cs
+++ b/src/tests/Bakabase.Tests/PathMarkReferenceValueRegressionTests.cs
@@ -6,6 +6,7 @@ using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using Bakabase.Abstractions.Components.Tasks;
+using Bakabase.Abstractions.Extensions;
 using Bakabase.Abstractions.Models.Domain;
 using Bakabase.Abstractions.Models.Domain.Constants;
 using Bakabase.Abstractions.Models.Dto;
@@ -22,6 +23,7 @@ using Bakabase.Modules.Property.Components.Properties.Multilevel;
 using Bakabase.Modules.Property.Components.Properties.Tags;
 using Bakabase.Modules.Property.Extensions;
 using Bakabase.Modules.StandardValue.Extensions;
+using Bakabase.Service.Controllers;
 using Bakabase.Service.Extensions;
 using Bakabase.Service.Models.Input;
 using Bakabase.TestKit.Utils;
@@ -550,6 +552,427 @@ public sealed class PathMarkReferenceValueRegressionTests
         preservedResourceValue.BizValue.Should().Be(guidLabel);
     }
 
+    [TestMethod]
+    public async Task Sync_V220SelectorlessPropertyMarks_ApplyToChildResource_AndAreImmediatelySearchable()
+    {
+        var avPath = Path.Combine(_testRoot, "TBD", "AV");
+        var resourcePath = Path.Combine(avPath, "Work-001");
+        Directory.CreateDirectory(resourcePath);
+
+        var pathMarkService = _sp.GetRequiredService<IPathMarkService>();
+        var resourceService = _sp.GetRequiredService<IResourceService>();
+        var propertyService = _sp.GetRequiredService<ICustomPropertyService>();
+        var propertyValueService = _sp.GetRequiredService<ICustomPropertyValueService>();
+        var effectService = _sp.GetRequiredService<IPathMarkEffectService>();
+
+        var statusProperty = await AddProperty("Status", PropertyType.SingleChoice);
+        var textProperty = await AddProperty("Status text", PropertyType.SingleLineText);
+        var legacyRegexProperty = await AddProperty("Legacy resource code", PropertyType.SingleLineText);
+        var migratedRegexProperty = await AddProperty("Migrated resource code", PropertyType.SingleLineText);
+        var modernRegexProperty = await AddProperty("Modern mark code", PropertyType.SingleLineText);
+
+        await pathMarkService.Add(new PathMark
+        {
+            Path = avPath,
+            Type = PathMarkType.Resource,
+            ConfigJson = JsonConvert.SerializeObject(new ResourceMarkConfig
+            {
+                MatchMode = PathMatchMode.Layer,
+                Layer = 1,
+                FsTypeFilter = PathFilterFsType.Directory,
+                ApplyScope = PathMarkApplyScope.MatchedOnly
+            }),
+            Priority = 0
+        });
+
+        // This is the exact shape emitted by V220: the applicability selector has
+        // matchMode=Layer, but both layer and regex are absent. ValueLayer=-1 means
+        // the parent of AV (TBD) is the dynamic business value.
+        var statusMark = await pathMarkService.Add(new PathMark
+        {
+            Path = avPath,
+            Type = PathMarkType.Property,
+            ConfigJson = BuildV220SelectorlessPropertyConfig(statusProperty.Id),
+            Priority = 100
+        });
+        var textMark = await pathMarkService.Add(new PathMark
+        {
+            Path = avPath,
+            Type = PathMarkType.Property,
+            ConfigJson = BuildV220SelectorlessPropertyConfig(textProperty.Id),
+            Priority = 100
+        });
+        var regexMark = await pathMarkService.Add(new PathMark
+        {
+            Path = avPath,
+            Type = PathMarkType.Property,
+            ConfigJson = BuildV220SelectorlessRegexPropertyConfig(legacyRegexProperty.Id, @"^(Work)-(?:\d+)$"),
+            Priority = 100
+        });
+        var migratedRegexMark = await pathMarkService.Add(new PathMark
+        {
+            Path = avPath,
+            Type = PathMarkType.Property,
+            ConfigJson = JsonConvert.SerializeObject(new PropertyMarkConfig
+            {
+                MatchMode = PathMatchMode.Layer,
+                Layer = 0,
+                Pool = PropertyPool.Custom,
+                PropertyId = migratedRegexProperty.Id,
+                ValueType = PropertyValueType.Dynamic,
+                ValueRegex = @"^(Work)-(?:\d+)$",
+                ValueRegexMatchesResourcePath = true,
+                ApplyScope = PathMarkApplyScope.MatchedAndSubdirectories
+            }),
+            Priority = 100
+        });
+        var modernRegexMark = await pathMarkService.Add(new PathMark
+        {
+            Path = avPath,
+            Type = PathMarkType.Property,
+            ConfigJson = JsonConvert.SerializeObject(new PropertyMarkConfig
+            {
+                MatchMode = PathMatchMode.Layer,
+                Layer = 0,
+                Pool = PropertyPool.Custom,
+                PropertyId = modernRegexProperty.Id,
+                ValueType = PropertyValueType.Dynamic,
+                ValueRegex = "^(AV)$",
+                ApplyScope = PathMarkApplyScope.MatchedAndSubdirectories
+            }),
+            Priority = 100
+        });
+
+        await SyncPendingResources();
+
+        var resource = (await resourceService.GetAll()).Should()
+            .ContainSingle(r => r.Path == resourcePath).Subject;
+        resource.Status.Should().Be(ResourceStatus.Active);
+
+        // Keep the index ready before property sync. Assertions below intentionally run
+        // immediately after SyncMarks returns, without a rebuild, delay, or polling.
+        await RebuildSearchIndex();
+        await SyncPendingPropertyMarks();
+
+        var statusEffect = (await effectService.GetPropertyEffectsByMarkId(statusMark.Id))
+            .Should().ContainSingle().Subject;
+        statusEffect.ResourceId.Should().Be(resource.Id);
+        statusEffect.Value.Should().Be("TBD",
+            "path-mark effects store the extracted business label, not a reference id");
+
+        var textEffect = (await effectService.GetPropertyEffectsByMarkId(textMark.Id))
+            .Should().ContainSingle().Subject;
+        textEffect.ResourceId.Should().Be(resource.Id);
+        textEffect.Value.Should().Be("TBD",
+            "selector compatibility must apply before property-type conversion");
+
+        var regexEffect = (await effectService.GetPropertyEffectsByMarkId(regexMark.Id))
+            .Should().ContainSingle().Subject;
+        regexEffect.ResourceId.Should().Be(resource.Id);
+        regexEffect.Value.Should().Be("Work",
+            "a V220 regex locator extracts each resource's path relative to the old media-library root");
+        (await effectService.GetPropertyEffectsByMarkId(migratedRegexMark.Id))
+            .Should().ContainSingle().Which.Value.Should().Be("Work",
+                "the corrected V220 representation must retain resource-relative regex semantics");
+        (await effectService.GetPropertyEffectsByMarkId(modernRegexMark.Id))
+            .Should().ContainSingle().Which.Value.Should().Be("AV",
+                "modern property regex extraction remains relative to the mark directory");
+
+        var refreshedStatus = await propertyService.GetByKey(statusProperty.Id);
+        var choice = refreshedStatus.Options.Should().BeOfType<SingleChoicePropertyOptions>()
+            .Subject.Choices.Should().ContainSingle().Subject;
+        choice.Label.Should().Be("TBD");
+        Guid.TryParse(choice.Value, out _).Should().BeTrue("reference values are stored as generated UUIDs");
+        choice.Value.Should().NotBe(choice.Label);
+
+        var statusValue = (await propertyValueService.GetAllDbModels(v =>
+                v.ResourceId == resource.Id &&
+                v.PropertyId == statusProperty.Id &&
+                v.Scope == (int) PropertyValueScope.Synchronization))
+            .Should().ContainSingle().Subject;
+        statusValue.Value.Should().Be(choice.Value);
+
+        var textValue = (await propertyValueService.GetAllDbModels(v =>
+                v.ResourceId == resource.Id &&
+                v.PropertyId == textProperty.Id &&
+                v.Scope == (int) PropertyValueScope.Synchronization))
+            .Should().ContainSingle().Subject;
+        textValue.Value.Should().Be("TBD");
+
+        var regexValue = (await propertyValueService.GetAllDbModels(v =>
+                v.ResourceId == resource.Id &&
+                v.PropertyId == legacyRegexProperty.Id &&
+                v.Scope == (int) PropertyValueScope.Synchronization))
+            .Should().ContainSingle().Subject;
+        regexValue.Value.Should().Be("Work");
+        (await propertyValueService.GetAllDbModels(v =>
+                v.ResourceId == resource.Id &&
+                v.PropertyId == migratedRegexProperty.Id &&
+                v.Scope == (int) PropertyValueScope.Synchronization))
+            .Should().ContainSingle().Which.Value.Should().Be("Work");
+        (await propertyValueService.GetAllDbModels(v =>
+                v.ResourceId == resource.Id &&
+                v.PropertyId == modernRegexProperty.Id &&
+                v.Scope == (int) PropertyValueScope.Synchronization))
+            .Should().ContainSingle().Which.Value.Should().Be("AV");
+
+        await AssertSingleChoiceInSearchMatches(resource.Id, statusProperty.Id, choice.Value);
+
+        var countResponse = await ActivatorUtilities.CreateInstance<PropertyController>(_sp)
+            .GetValueResourceCounts(PropertyPool.Custom, statusProperty.Id, new ResourceSearchInputModel());
+        countResponse.Data.Should().NotBeNull();
+        countResponse.Data!.IsReady.Should().BeTrue();
+        countResponse.Data.Counts.Should().ContainKey(choice.Value);
+        countResponse.Data.Counts[choice.Value].Should().Be(1);
+    }
+
+    [TestMethod]
+    public async Task Sync_LegacyPropertyFallback_DoesNotExpandExplicitPropertyOrMediaLibrarySelectors()
+    {
+        var avPath = Path.Combine(_testRoot, "TBD", "AV");
+        var resourcePath = Path.Combine(avPath, "Work-001");
+        Directory.CreateDirectory(resourcePath);
+
+        var pathMarkService = _sp.GetRequiredService<IPathMarkService>();
+        var resourceService = _sp.GetRequiredService<IResourceService>();
+        var propertyValueService = _sp.GetRequiredService<ICustomPropertyValueService>();
+        var effectService = _sp.GetRequiredService<IPathMarkEffectService>();
+        var mediaLibraryService = _sp.GetRequiredService<IMediaLibraryV2Service>();
+        var mappingService = _sp.GetRequiredService<IMediaLibraryResourceMappingService>();
+
+        var explicitProperty = await AddProperty("Explicit current-layer property", PropertyType.SingleLineText);
+        var fixedSelectorlessProperty = await AddProperty("Malformed fixed property", PropertyType.SingleLineText);
+        var dynamicSelectorlessProperty = await AddProperty(
+            "Malformed dynamic property without extractor", PropertyType.SingleLineText);
+        var explicitMissingExtractorProperty = await AddProperty(
+            "Explicit dynamic property without extractor", PropertyType.SingleLineText);
+        var migratedRegexProperty = await AddProperty("Migrated regex property", PropertyType.SingleLineText);
+        var currentDirectoryLibrary = await mediaLibraryService.Add(
+            new MediaLibraryV2AddOrPutInputModel("Current directory only", []));
+        var childDirectoryLibrary = await mediaLibraryService.Add(
+            new MediaLibraryV2AddOrPutInputModel("Direct children", []));
+        var selectorlessLibrary = await mediaLibraryService.Add(
+            new MediaLibraryV2AddOrPutInputModel("Malformed selectorless media library", []));
+
+        await pathMarkService.Add(new PathMark
+        {
+            Path = avPath,
+            Type = PathMarkType.Resource,
+            ConfigJson = JsonConvert.SerializeObject(new ResourceMarkConfig
+            {
+                MatchMode = PathMatchMode.Layer,
+                Layer = 1,
+                FsTypeFilter = PathFilterFsType.Directory,
+                ApplyScope = PathMarkApplyScope.MatchedOnly
+            }),
+            Priority = 0
+        });
+
+        var explicitPropertyMark = await pathMarkService.Add(new PathMark
+        {
+            Path = avPath,
+            Type = PathMarkType.Property,
+            ConfigJson = JsonConvert.SerializeObject(new PropertyMarkConfig
+            {
+                MatchMode = PathMatchMode.Layer,
+                Layer = 0,
+                Pool = PropertyPool.Custom,
+                PropertyId = explicitProperty.Id,
+                ValueType = PropertyValueType.Fixed,
+                FixedValue = "must-not-reach-child",
+                ApplyScope = PathMarkApplyScope.MatchedOnly
+            }),
+            Priority = 100
+        });
+        var fixedSelectorlessPropertyMark = await pathMarkService.Add(new PathMark
+        {
+            Path = avPath,
+            Type = PathMarkType.Property,
+            ConfigJson = BuildSelectorlessFixedPropertyConfig(
+                fixedSelectorlessProperty.Id, "must-not-use-legacy-fallback"),
+            Priority = 100
+        });
+        var dynamicSelectorlessPropertyMark = await pathMarkService.Add(new PathMark
+        {
+            Path = avPath,
+            Type = PathMarkType.Property,
+            ConfigJson = BuildSelectorlessDynamicPropertyWithoutExtractorConfig(dynamicSelectorlessProperty.Id),
+            Priority = 100
+        });
+        var explicitMissingExtractorMark = await pathMarkService.Add(new PathMark
+        {
+            Path = avPath,
+            Type = PathMarkType.Property,
+            ConfigJson = JsonConvert.SerializeObject(new PropertyMarkConfig
+            {
+                MatchMode = PathMatchMode.Layer,
+                Layer = 0,
+                Pool = PropertyPool.Custom,
+                PropertyId = explicitMissingExtractorProperty.Id,
+                ValueType = PropertyValueType.Dynamic,
+                ApplyScope = PathMarkApplyScope.MatchedAndSubdirectories
+            }),
+            Priority = 100
+        });
+        var migratedRegexMark = await pathMarkService.Add(new PathMark
+        {
+            Path = avPath,
+            Type = PathMarkType.Property,
+            ConfigJson = JsonConvert.SerializeObject(new PropertyMarkConfig
+            {
+                MatchMode = PathMatchMode.Layer,
+                Layer = 0,
+                Pool = PropertyPool.Custom,
+                PropertyId = migratedRegexProperty.Id,
+                ValueType = PropertyValueType.Dynamic,
+                ValueRegex = @"^(Work)",
+                ValueRegexMatchesResourcePath = true,
+                ApplyScope = PathMarkApplyScope.MatchedAndSubdirectories
+            }),
+            Priority = 100
+        });
+        var currentDirectoryMediaMark = await pathMarkService.Add(new PathMark
+        {
+            Path = avPath,
+            Type = PathMarkType.MediaLibrary,
+            ConfigJson = JsonConvert.SerializeObject(new MediaLibraryMarkConfig
+            {
+                MatchMode = PathMatchMode.Layer,
+                Layer = 0,
+                ValueType = PropertyValueType.Fixed,
+                MediaLibraryId = currentDirectoryLibrary.Id,
+                ApplyScope = PathMarkApplyScope.MatchedOnly
+            }),
+            Priority = 100
+        });
+        var childDirectoryMediaMark = await pathMarkService.Add(new PathMark
+        {
+            Path = avPath,
+            Type = PathMarkType.MediaLibrary,
+            ConfigJson = JsonConvert.SerializeObject(new MediaLibraryMarkConfig
+            {
+                MatchMode = PathMatchMode.Layer,
+                Layer = 1,
+                ValueType = PropertyValueType.Fixed,
+                MediaLibraryId = childDirectoryLibrary.Id,
+                ApplyScope = PathMarkApplyScope.MatchedOnly
+            }),
+            Priority = 100
+        });
+        var selectorlessMediaMark = await pathMarkService.Add(new PathMark
+        {
+            Path = avPath,
+            Type = PathMarkType.MediaLibrary,
+            ConfigJson = BuildSelectorlessFixedMediaLibraryConfig(selectorlessLibrary.Id),
+            Priority = 100
+        });
+
+        await SyncPendingResources();
+        await SyncPendingPropertyMarks();
+
+        var resource = (await resourceService.GetAll()).Should()
+            .ContainSingle(r => r.Path == resourcePath).Subject;
+        (await effectService.GetPropertyEffectsByMarkId(migratedRegexMark.Id))
+            .Should().ContainSingle().Which.Value.Should().Be("Work");
+        (await propertyValueService.GetAllDbModels(v =>
+                v.ResourceId == resource.Id && v.PropertyId == migratedRegexProperty.Id))
+            .Should().ContainSingle().Which.Value.Should().Be("Work");
+
+        var markWithClearedRegex = (await pathMarkService.Get(migratedRegexMark.Id))!;
+        markWithClearedRegex.ConfigJson = JsonConvert.SerializeObject(new PropertyMarkConfig
+        {
+            MatchMode = PathMatchMode.Layer,
+            Layer = 0,
+            Pool = PropertyPool.Custom,
+            PropertyId = migratedRegexProperty.Id,
+            ValueType = PropertyValueType.Dynamic,
+            ValueLayer = -1,
+            ValueRegex = string.Empty,
+            ValueRegexMatchesResourcePath = true,
+            ApplyScope = PathMarkApplyScope.MatchedAndSubdirectories
+        });
+        await pathMarkService.Update(markWithClearedRegex);
+        await SyncPendingPropertyMarks();
+
+        (await effectService.GetPropertyEffectsByMarkId(explicitPropertyMark.Id)).Should().BeEmpty(
+            "an explicit layer=0 + MatchedOnly property mark must not expand to child resources");
+        (await propertyValueService.GetAllDbModels(v =>
+                v.ResourceId == resource.Id && v.PropertyId == explicitProperty.Id))
+            .Should().BeEmpty();
+        (await effectService.GetPropertyEffectsByMarkId(fixedSelectorlessPropertyMark.Id)).Should().BeEmpty(
+            "only V220 dynamic locators qualify for selectorless compatibility");
+        (await propertyValueService.GetAllDbModels(v =>
+                v.ResourceId == resource.Id && v.PropertyId == fixedSelectorlessProperty.Id))
+            .Should().BeEmpty();
+        (await effectService.GetPropertyEffectsByMarkId(dynamicSelectorlessPropertyMark.Id)).Should().BeEmpty(
+            "a dynamic mark without a value layer or value regex is malformed, not a V220 locator");
+        (await propertyValueService.GetAllDbModels(v =>
+                v.ResourceId == resource.Id && v.PropertyId == dynamicSelectorlessProperty.Id))
+            .Should().BeEmpty();
+        (await effectService.GetPropertyEffectsByMarkId(explicitMissingExtractorMark.Id)).Should().BeEmpty(
+            "a missing dynamic extractor must not silently fall back to layer zero");
+        (await propertyValueService.GetAllDbModels(v =>
+                v.ResourceId == resource.Id && v.PropertyId == explicitMissingExtractorProperty.Id))
+            .Should().BeEmpty();
+        (await effectService.GetPropertyEffectsByMarkId(migratedRegexMark.Id)).Should().BeEmpty(
+            "a cleared migrated regex must not silently fall back to its stale value layer");
+        (await propertyValueService.GetAllDbModels(v =>
+                v.ResourceId == resource.Id && v.PropertyId == migratedRegexProperty.Id))
+            .Should().BeEmpty();
+
+        (await effectService.GetPropertyEffectsByMarkId(currentDirectoryMediaMark.Id)).Should().BeEmpty(
+            "legacy compatibility is property-specific and must not change media-library selectors");
+        (await effectService.GetPropertyEffectsByMarkId(selectorlessMediaMark.Id)).Should().BeEmpty(
+            "a selectorless media-library mark is malformed, not a V220 property locator");
+        var childMediaEffect = (await effectService.GetPropertyEffectsByMarkId(childDirectoryMediaMark.Id))
+            .Should().ContainSingle().Subject;
+        childMediaEffect.ResourceId.Should().Be(resource.Id);
+        childMediaEffect.Value.Should().Be(childDirectoryLibrary.Id.ToString());
+
+        var mediaLibraryIds = await mappingService.GetMediaLibraryIdsByResourceId(resource.Id);
+        mediaLibraryIds.Should().BeEquivalentTo([childDirectoryLibrary.Id]);
+    }
+
+    [TestMethod]
+    public void LegacyWildcardApplicability_RequiresTheV220MatchModeAndExtractorPair()
+    {
+        var baseConfig = new PropertyMarkConfig
+        {
+            MatchMode = PathMatchMode.Layer,
+            Pool = PropertyPool.Custom,
+            PropertyId = 1,
+            ValueType = PropertyValueType.Dynamic,
+            ValueLayer = -1,
+            ApplyScope = PathMarkApplyScope.MatchedOnly
+        };
+
+        baseConfig.UsesLegacyV220WildcardApplicability().Should().BeTrue();
+
+        new PropertyMarkConfig
+        {
+            MatchMode = (PathMatchMode) 0,
+            ValueType = PropertyValueType.Dynamic,
+            ValueLayer = -1,
+            ApplyScope = PathMarkApplyScope.MatchedOnly
+        }.UsesLegacyV220WildcardApplicability().Should().BeFalse();
+
+        new PropertyMarkConfig
+        {
+            MatchMode = PathMatchMode.Regex,
+            ValueType = PropertyValueType.Dynamic,
+            ValueLayer = -1,
+            ApplyScope = PathMarkApplyScope.MatchedOnly
+        }.UsesLegacyV220WildcardApplicability().Should().BeFalse();
+
+        new PropertyMarkConfig
+        {
+            MatchMode = PathMatchMode.Layer,
+            ValueType = PropertyValueType.Dynamic,
+            ValueRegex = "^(AV)$",
+            ApplyScope = PathMarkApplyScope.MatchedOnly
+        }.UsesLegacyV220WildcardApplicability().Should().BeFalse();
+    }
+
     private async Task<CustomProperty> AddProperty(string name, PropertyType type, object? options = null)
     {
         return await _sp.GetRequiredService<ICustomPropertyService>().Add(new CustomPropertyAddOrPutDto
@@ -603,6 +1026,45 @@ public sealed class PathMarkReferenceValueRegressionTests
             FixedValue = fixedValue,
             ApplyScope = PathMarkApplyScope.MatchedOnly
         });
+    }
+
+    private static string BuildV220SelectorlessPropertyConfig(int propertyId)
+    {
+        return $"{{\"matchMode\":1,\"pool\":4,\"propertyId\":{propertyId},\"valueType\":2," +
+               "\"valueLayer\":-1,\"applyScope\":1}";
+    }
+
+    private static string BuildV220SelectorlessRegexPropertyConfig(int propertyId, string valueRegex)
+    {
+        return $"{{\"matchMode\":2,\"pool\":4,\"propertyId\":{propertyId},\"valueType\":2," +
+               $"\"valueRegex\":{JsonConvert.SerializeObject(valueRegex)},\"applyScope\":1}}";
+    }
+
+    private static string BuildSelectorlessFixedPropertyConfig(int propertyId, string fixedValue)
+    {
+        return $"{{\"matchMode\":1,\"pool\":4,\"propertyId\":{propertyId},\"valueType\":1," +
+               $"\"fixedValue\":{JsonConvert.SerializeObject(fixedValue)},\"applyScope\":1}}";
+    }
+
+    private static string BuildSelectorlessDynamicPropertyWithoutExtractorConfig(int propertyId)
+    {
+        return $"{{\"matchMode\":1,\"pool\":4,\"propertyId\":{propertyId},\"valueType\":2," +
+               "\"applyScope\":1}";
+    }
+
+    private static string BuildSelectorlessFixedMediaLibraryConfig(int mediaLibraryId)
+    {
+        return $"{{\"matchMode\":1,\"valueType\":1,\"mediaLibraryId\":{mediaLibraryId},\"applyScope\":1}}";
+    }
+
+    private async Task SyncPendingResources()
+    {
+        await _sp.GetRequiredService<ResourceSyncService>().SyncResources(
+            ResourceSource.PathMark,
+            null,
+            null,
+            new PauseToken(),
+            CancellationToken.None);
     }
 
     private async Task SyncPendingPropertyMarks()

--- a/src/web/src/locales/cn/pages/pathMarkConfig.json
+++ b/src/web/src/locales/cn/pages/pathMarkConfig.json
@@ -102,6 +102,8 @@
   "pathMarkConfig.tip.zeroEqualsMatchedItem": "0 = 匹配项",
   "pathMarkConfig.label.valueRegex": "值正则表达式",
   "pathMarkConfig.tip.regexExample": "例如：\\\\[(.+?)\\\\]",
+  "pathMarkConfig.error.valueLayerRequired": "请选择用于提取属性值的层级",
+  "pathMarkConfig.error.valueRegexRequired": "请输入用于提取属性值的正则表达式",
   "pathMarkConfig.label.mediaLibrarySettings": "媒体库设置",
   "pathMarkConfig.label.targetMediaLibrary": "目标媒体库",
   "pathMarkConfig.empty.noMediaLibrarySelected": "未选择媒体库",

--- a/src/web/src/locales/en/pages/pathMarkConfig.json
+++ b/src/web/src/locales/en/pages/pathMarkConfig.json
@@ -102,6 +102,8 @@
   "pathMarkConfig.tip.zeroEqualsMatchedItem": "0 = matched item",
   "pathMarkConfig.label.valueRegex": "Value Regex",
   "pathMarkConfig.tip.regexExample": "e.g., \\\\[(.+?)\\\\]",
+  "pathMarkConfig.error.valueLayerRequired": "Select a layer to extract the property value from",
+  "pathMarkConfig.error.valueRegexRequired": "Enter a regular expression to extract the property value",
   "pathMarkConfig.label.mediaLibrarySettings": "Media Library Settings",
   "pathMarkConfig.label.targetMediaLibrary": "Target Media Library",
   "pathMarkConfig.empty.noMediaLibrarySelected": "No media library selected",

--- a/src/web/src/pages/path-mark-config/components/MarkConfigModal/__tests__/utils.test.ts
+++ b/src/web/src/pages/path-mark-config/components/MarkConfigModal/__tests__/utils.test.ts
@@ -1,0 +1,240 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildConfigJson,
+  hasValidPropertyValueExtractor,
+  normalizeLegacyPropertyMarkConfig,
+  parseMarkConfig,
+} from "../utils";
+
+import {
+  PathMarkApplyScope,
+  PathMarkType,
+  PathMatchMode,
+  PropertyValueType,
+} from "@/sdk/constants";
+
+const legacyPropertyConfig = {
+  matchMode: PathMatchMode.Layer,
+  pool: 4,
+  propertyId: 52,
+  valueType: PropertyValueType.Dynamic,
+  valueLayer: -1,
+  applyScope: PathMarkApplyScope.MatchedOnly,
+};
+
+describe("legacy V220 property mark compatibility", () => {
+  it("restores the original all-resources-under-path applicability", () => {
+    const config = parseMarkConfig(JSON.stringify(legacyPropertyConfig), PathMarkType.Property);
+
+    expect(config).toMatchObject({
+      matchMode: PathMatchMode.Layer,
+      layer: 0,
+      applyScope: PathMarkApplyScope.MatchedAndSubdirectories,
+      propertyPool: 4,
+      propertyId: 52,
+      valueType: PropertyValueType.Dynamic,
+      valueLayer: -1,
+    });
+  });
+
+  it("persists an explicit selector instead of layer zero plus matched-only", () => {
+    const config = parseMarkConfig(JSON.stringify(legacyPropertyConfig), PathMarkType.Property);
+    const configJson = buildConfigJson(config, PathMarkType.Property);
+
+    expect(JSON.parse(configJson)).toMatchObject({
+      matchMode: PathMatchMode.Layer,
+      layer: 0,
+      applyScope: PathMarkApplyScope.MatchedAndSubdirectories,
+      pool: 4,
+      propertyId: 52,
+      valueLayer: -1,
+    });
+  });
+
+  it("preserves a legacy regex value extractor while canonicalizing its selector", () => {
+    const config = parseMarkConfig(
+      JSON.stringify({
+        ...legacyPropertyConfig,
+        matchMode: PathMatchMode.Regex,
+        valueLayer: undefined,
+        valueRegex: "^([^/]+)$",
+      }),
+      PathMarkType.Property,
+    );
+    const savedConfig = JSON.parse(buildConfigJson(config, PathMarkType.Property));
+
+    expect(config).toMatchObject({
+      matchMode: PathMatchMode.Layer,
+      layer: 0,
+      applyScope: PathMarkApplyScope.MatchedAndSubdirectories,
+      valueMatchMode: PathMatchMode.Regex,
+      valueRegex: "^([^/]+)$",
+    });
+    expect(savedConfig).toMatchObject({
+      matchMode: PathMatchMode.Layer,
+      layer: 0,
+      applyScope: PathMarkApplyScope.MatchedAndSubdirectories,
+      valueRegex: "^([^/]+)$",
+      valueRegexMatchesResourcePath: true,
+    });
+    expect(savedConfig).not.toHaveProperty("valueLayer");
+  });
+
+  it("treats an omitted V220 apply scope as its backend default", () => {
+    const config = parseMarkConfig(
+      JSON.stringify({
+        ...legacyPropertyConfig,
+        applyScope: undefined,
+      }),
+      PathMarkType.Property,
+    );
+
+    expect(config).toMatchObject({
+      matchMode: PathMatchMode.Layer,
+      layer: 0,
+      applyScope: PathMarkApplyScope.MatchedAndSubdirectories,
+      valueLayer: -1,
+    });
+  });
+
+  it("does not expand an explicit modern property selector", () => {
+    const config = parseMarkConfig(
+      JSON.stringify({
+        ...legacyPropertyConfig,
+        layer: 0,
+      }),
+      PathMarkType.Property,
+    );
+
+    expect(config.layer).toBe(0);
+    expect(config.applyScope).toBe(PathMarkApplyScope.MatchedOnly);
+  });
+
+  it("does not apply property compatibility to other mark types", () => {
+    const config = normalizeLegacyPropertyMarkConfig(
+      { ...legacyPropertyConfig },
+      PathMarkType.MediaLibrary,
+    );
+
+    expect(config).toEqual(legacyPropertyConfig);
+  });
+
+  it("requires the V220 match mode and value extractor to agree", () => {
+    const unknownMode = normalizeLegacyPropertyMarkConfig(
+      { ...legacyPropertyConfig, matchMode: 0 as PathMatchMode },
+      PathMarkType.Property,
+    );
+    const mismatchedLayer = normalizeLegacyPropertyMarkConfig(
+      {
+        ...legacyPropertyConfig,
+        matchMode: PathMatchMode.Regex,
+      },
+      PathMarkType.Property,
+    );
+    const mismatchedRegex = normalizeLegacyPropertyMarkConfig(
+      {
+        ...legacyPropertyConfig,
+        matchMode: PathMatchMode.Layer,
+        valueLayer: undefined,
+        valueRegex: "^(AV)$",
+      },
+      PathMarkType.Property,
+    );
+
+    expect(unknownMode).toEqual({ ...legacyPropertyConfig, matchMode: 0 });
+    expect(mismatchedLayer).toEqual({
+      ...legacyPropertyConfig,
+      matchMode: PathMatchMode.Regex,
+    });
+    expect(mismatchedRegex).toEqual({
+      ...legacyPropertyConfig,
+      matchMode: PathMatchMode.Layer,
+      valueLayer: undefined,
+      valueRegex: "^(AV)$",
+    });
+  });
+
+  it("does not repair malformed or fixed-value property configs while saving", () => {
+    const rawFixedConfig = {
+      ...legacyPropertyConfig,
+      valueType: PropertyValueType.Fixed,
+    };
+    const rawMissingExtractorConfig = {
+      ...legacyPropertyConfig,
+      valueLayer: undefined,
+    };
+    const fixedConfig = JSON.parse(
+      buildConfigJson(
+        parseMarkConfig(JSON.stringify(rawFixedConfig), PathMarkType.Property),
+        PathMarkType.Property,
+      ),
+    );
+    const missingExtractorConfig = JSON.parse(
+      buildConfigJson(
+        parseMarkConfig(JSON.stringify(rawMissingExtractorConfig), PathMarkType.Property),
+        PathMarkType.Property,
+      ),
+    );
+
+    expect(fixedConfig).not.toHaveProperty("layer");
+    expect(fixedConfig).not.toHaveProperty("regex");
+    expect(missingExtractorConfig).not.toHaveProperty("layer");
+    expect(missingExtractorConfig).not.toHaveProperty("regex");
+    expect(missingExtractorConfig).not.toHaveProperty("valueLayer");
+    expect(missingExtractorConfig).not.toHaveProperty("valueRegex");
+  });
+
+  it("keeps the existing defaults for a newly created property mark", () => {
+    const config = parseMarkConfig(undefined, PathMarkType.Property);
+
+    expect(config.layer).toBe(0);
+    expect(config.valueLayer).toBe(0);
+    expect(config.applyScope).toBe(PathMarkApplyScope.MatchedOnly);
+  });
+
+  it("keeps a cleared migrated regex in regex mode and rejects saving it", () => {
+    const config = parseMarkConfig(
+      JSON.stringify({
+        ...legacyPropertyConfig,
+        matchMode: PathMatchMode.Layer,
+        layer: 0,
+        valueLayer: undefined,
+        valueRegex: "",
+        valueRegexMatchesResourcePath: true,
+        applyScope: PathMarkApplyScope.MatchedAndSubdirectories,
+      }),
+      PathMarkType.Property,
+    );
+
+    expect(config.valueMatchMode).toBe(PathMatchMode.Regex);
+    expect(hasValidPropertyValueExtractor(config, PathMarkType.Property)).toBe(false);
+  });
+
+  it("requires an explicit extractor only for dynamic property marks", () => {
+    const missingLayer = {
+      ...parseMarkConfig(JSON.stringify({}), PathMarkType.Property),
+      valueType: PropertyValueType.Dynamic,
+      valueMatchMode: PathMatchMode.Layer,
+      valueLayer: undefined,
+    };
+
+    expect(hasValidPropertyValueExtractor(missingLayer, PathMarkType.Property)).toBe(false);
+    expect(
+      hasValidPropertyValueExtractor({ ...missingLayer, valueLayer: 0 }, PathMarkType.Property),
+    ).toBe(true);
+    expect(
+      hasValidPropertyValueExtractor(
+        { ...missingLayer, valueLayer: Number.NaN },
+        PathMarkType.Property,
+      ),
+    ).toBe(false);
+    expect(
+      hasValidPropertyValueExtractor(
+        { ...missingLayer, valueMatchMode: PathMatchMode.Regex, valueRegex: "^(AV)$" },
+        PathMarkType.Property,
+      ),
+    ).toBe(true);
+    expect(hasValidPropertyValueExtractor(missingLayer, PathMarkType.MediaLibrary)).toBe(true);
+  });
+});

--- a/src/web/src/pages/path-mark-config/components/MarkConfigModal/components/MatchModeSelector.tsx
+++ b/src/web/src/pages/path-mark-config/components/MarkConfigModal/components/MatchModeSelector.tsx
@@ -38,7 +38,14 @@ const MatchModeSelector = ({ config, updateConfig, t, markType }: Props) => {
           orientation="horizontal"
           size="sm"
           value={String(config.matchMode)}
-          onValueChange={(value) => updateConfig({ matchMode: Number(value) })}
+          onValueChange={(value) => {
+            const matchMode = Number(value) as PathMatchMode;
+
+            updateConfig({
+              matchMode,
+              ...(matchMode === PathMatchMode.Layer && config.layer == null ? { layer: 0 } : {}),
+            });
+          }}
         >
           <Radio value={String(PathMatchMode.Layer)}>{t("pathMarkConfig.label.layer")}</Radio>
           <Radio value={String(PathMatchMode.Regex)}>{t("pathMarkConfig.label.regex")}</Radio>

--- a/src/web/src/pages/path-mark-config/components/MarkConfigModal/components/PropertyMarkConfig.tsx
+++ b/src/web/src/pages/path-mark-config/components/MarkConfigModal/components/PropertyMarkConfig.tsx
@@ -43,6 +43,8 @@ const PropertyMarkConfig = ({
 }: Props) => {
   const { createPortal } = useBakabaseContext();
   const [selectedProperty, setSelectedProperty] = useState<IProperty | null>(null);
+  const hasValidValueLayer =
+    typeof config.valueLayer === "number" && Number.isFinite(config.valueLayer);
 
   // Load selected property info on mount if we have propertyId
   useEffect(() => {
@@ -164,7 +166,18 @@ const PropertyMarkConfig = ({
           orientation="horizontal"
           size="sm"
           value={String(config.valueType ?? PropertyValueType.Fixed)}
-          onValueChange={(value) => updateConfig({ valueType: Number(value) })}
+          onValueChange={(value) => {
+            const valueType = Number(value) as PropertyValueType;
+
+            updateConfig({
+              valueType,
+              ...(valueType === PropertyValueType.Dynamic &&
+              !hasValidValueLayer &&
+              !config.valueRegex
+                ? { valueLayer: 0 }
+                : {}),
+            });
+          }}
         >
           <Radio value={String(PropertyValueType.Fixed)}>{t("pathMarkConfig.label.fixed")}</Radio>
           <Radio value={String(PropertyValueType.Dynamic)}>
@@ -191,7 +204,19 @@ const PropertyMarkConfig = ({
               orientation="horizontal"
               size="sm"
               value={String(config.valueMatchMode ?? PathMatchMode.Layer)}
-              onValueChange={(value) => updateConfig({ valueMatchMode: Number(value) })}
+              onValueChange={(value) => {
+                const valueMatchMode = Number(value) as PathMatchMode;
+
+                updateConfig({
+                  valueMatchMode,
+                  ...(valueMatchMode === PathMatchMode.Layer && !hasValidValueLayer
+                    ? { valueLayer: 0 }
+                    : {}),
+                  ...(valueMatchMode === PathMatchMode.Layer
+                    ? { valueRegexMatchesResourcePath: undefined }
+                    : {}),
+                });
+              }}
             >
               <Radio value={String(PathMatchMode.Layer)}>{t("pathMarkConfig.label.layer")}</Radio>
               <Radio value={String(PathMatchMode.Regex)}>{t("pathMarkConfig.label.regex")}</Radio>
@@ -201,13 +226,25 @@ const PropertyMarkConfig = ({
           {config.valueMatchMode === PathMatchMode.Layer ? (
             <NumberInput
               description={t("pathMarkConfig.tip.zeroEqualsMatchedItem")}
+              errorMessage={
+                !hasValidValueLayer ? t("pathMarkConfig.error.valueLayerRequired") : undefined
+              }
+              isInvalid={!hasValidValueLayer}
               label={t("pathMarkConfig.label.valueLayer")}
               size="sm"
-              value={config.valueLayer ?? 0}
-              onValueChange={(v) => updateConfig({ valueLayer: v })}
+              value={hasValidValueLayer ? config.valueLayer : undefined}
+              onValueChange={(v) =>
+                updateConfig({ valueLayer: Number.isFinite(v) ? v : undefined })
+              }
             />
           ) : (
             <Input
+              errorMessage={
+                !config.valueRegex?.trim()
+                  ? t("pathMarkConfig.error.valueRegexRequired")
+                  : undefined
+              }
+              isInvalid={!config.valueRegex?.trim()}
               label={t("pathMarkConfig.label.valueRegex")}
               placeholder={t("pathMarkConfig.tip.regexExample")}
               size="sm"

--- a/src/web/src/pages/path-mark-config/components/MarkConfigModal/hooks/usePreview.ts
+++ b/src/web/src/pages/path-mark-config/components/MarkConfigModal/hooks/usePreview.ts
@@ -113,18 +113,7 @@ export const usePreview = (
         clearTimeout(timeoutRef.current);
       }
     };
-  }, [
-    effectivePaths,
-    markType,
-    config.matchMode,
-    config.layer,
-    config.regex,
-    config.fsTypeFilter,
-    config.extensions,
-    config.extensionGroupIds,
-    config.applyScope,
-    debounceMs,
-  ]);
+  }, [effectivePaths, markType, config, debounceMs]);
 
   return {
     loading,

--- a/src/web/src/pages/path-mark-config/components/MarkConfigModal/index.tsx
+++ b/src/web/src/pages/path-mark-config/components/MarkConfigModal/index.tsx
@@ -7,7 +7,7 @@ import { useState, useCallback, useRef, useEffect } from "react";
 import { Trans, useTranslation } from "react-i18next";
 import { SaveOutlined, SyncOutlined, DownOutlined } from "@ant-design/icons";
 
-import { parseMarkConfig, buildConfigJson } from "./utils";
+import { parseMarkConfig, buildConfigJson, hasValidPropertyValueExtractor } from "./utils";
 import ResourceMarkConfig from "./components/ResourceMarkConfig";
 import PropertyMarkConfig from "./components/PropertyMarkConfig";
 import MediaLibraryMarkConfig from "./components/MediaLibraryMarkConfig";
@@ -31,7 +31,7 @@ const MarkConfigModal = ({
 }: MarkConfigModalProps) => {
   const { t } = useTranslation();
 
-  const initialConfig = parseMarkConfig(mark?.configJson);
+  const initialConfig = parseMarkConfig(mark?.configJson, markType);
 
   // For new MediaLibrary marks, default applyScope to MatchedAndSubdirectories
   if (!mark && markType === PathMarkType.MediaLibrary) {
@@ -50,6 +50,7 @@ const MarkConfigModal = ({
   const contentRef = useRef<HTMLDivElement>(null);
 
   const preview = usePreview(rootPath, markType, config, 500, rootPaths);
+  const hasValidValueExtractor = hasValidPropertyValueExtractor(config, markType);
 
   // Check if content is scrollable and update scroll indicator
   useEffect(() => {
@@ -83,6 +84,8 @@ const MarkConfigModal = ({
   }, [config, enableExpiration]);
 
   const handleSave = useCallback(async () => {
+    if (!hasValidValueExtractor) return false;
+
     const newMark: Partial<BakabaseAbstractionsModelsDomainPathMark> = {
       type: markType,
       priority,
@@ -93,7 +96,15 @@ const MarkConfigModal = ({
     await onSave?.(newMark as BakabaseAbstractionsModelsDomainPathMark);
 
     return true;
-  }, [markType, priority, config, enableExpiration, expiresInSeconds, onSave]);
+  }, [
+    markType,
+    priority,
+    config,
+    enableExpiration,
+    expiresInSeconds,
+    onSave,
+    hasValidValueExtractor,
+  ]);
 
   const handleSyncNow = useCallback(async () => {
     if (!mark?.id) return;
@@ -139,6 +150,7 @@ const MarkConfigModal = ({
         actions: ["cancel", "ok"],
         okProps: {
           children: t("common.action.save"),
+          isDisabled: !hasValidValueExtractor,
           startContent: <SaveOutlined />,
         },
         startContent: mark?.id ? (

--- a/src/web/src/pages/path-mark-config/components/MarkConfigModal/types.ts
+++ b/src/web/src/pages/path-mark-config/components/MarkConfigModal/types.ts
@@ -32,6 +32,7 @@ export interface MarkConfig {
   valueMatchMode?: PathMatchMode;
   valueLayer?: number;
   valueRegex?: string;
+  valueRegexMatchesResourcePath?: boolean;
   // For Resource type
   fsTypeFilter?: PathFilterFsType;
   extensions?: string[];

--- a/src/web/src/pages/path-mark-config/components/MarkConfigModal/utils.ts
+++ b/src/web/src/pages/path-mark-config/components/MarkConfigModal/utils.ts
@@ -7,22 +7,95 @@ import {
   PathMarkApplyScope,
 } from "@/sdk/constants";
 
-export const parseMarkConfig = (configJson?: string): MarkConfig => {
+type PropertyMarkCompatibilityConfig = {
+  matchMode?: PathMatchMode;
+  layer?: number | null;
+  regex?: string | null;
+  applyScope?: PathMarkApplyScope;
+  valueType?: PropertyValueType;
+  valueLayer?: number | null;
+  valueRegex?: string | null;
+  valueRegexMatchesResourcePath?: boolean;
+};
+
+type RawMarkConfig = PropertyMarkCompatibilityConfig & {
+  pool?: MarkConfig["propertyPool"];
+  propertyId?: number;
+  fixedValue?: string;
+  fsTypeFilter?: MarkConfig["fsTypeFilter"];
+  extensions?: string[];
+  extensionGroupIds?: number[];
+  isResourceBoundary?: boolean;
+  mediaLibraryId?: number;
+  layerToMediaLibrary?: number;
+  regexToMediaLibrary?: string;
+};
+
+/**
+ * V220 property marks did not persist an applicability selector. During the migration those marks
+ * were applied to every resource under the mark path, so preserve that meaning when the legacy
+ * shape is read by the current editor and preview.
+ */
+export const normalizeLegacyPropertyMarkConfig = <T extends PropertyMarkCompatibilityConfig>(
+  config: T,
+  markType: PathMarkType,
+): T => {
+  const hasLayer = config.layer !== undefined && config.layer !== null;
+  const hasRegex = typeof config.regex === "string" && config.regex.length > 0;
+  const hasValueLayer = config.valueLayer !== undefined && config.valueLayer !== null;
+  const hasValueRegex = typeof config.valueRegex === "string" && config.valueRegex.length > 0;
+  const isLegacyV220PropertyMark =
+    markType === PathMarkType.Property &&
+    config.valueType === PropertyValueType.Dynamic &&
+    (config.applyScope ?? PathMarkApplyScope.MatchedOnly) === PathMarkApplyScope.MatchedOnly &&
+    !hasLayer &&
+    !hasRegex &&
+    ((config.matchMode === PathMatchMode.Layer && hasValueLayer) ||
+      (config.matchMode === PathMatchMode.Regex && hasValueRegex));
+
+  if (!isLegacyV220PropertyMark) {
+    return config;
+  }
+
+  return {
+    ...config,
+    matchMode: PathMatchMode.Layer,
+    layer: 0,
+    regex: undefined,
+    applyScope: PathMarkApplyScope.MatchedAndSubdirectories,
+    valueRegexMatchesResourcePath:
+      config.matchMode === PathMatchMode.Regex && hasValueRegex
+        ? true
+        : config.valueRegexMatchesResourcePath,
+  } as T;
+};
+
+export const parseMarkConfig = (configJson?: string, markType?: PathMarkType): MarkConfig => {
   try {
-    const config = JSON.parse(configJson || "{}");
+    const parsedConfig = JSON.parse(configJson || "{}") as RawMarkConfig;
+    const isNewMark = configJson === undefined;
+    // No configJson means a new mark. Its defaults must not be mistaken for a migrated V220 mark.
+    const config =
+      !isNewMark && markType !== undefined
+        ? normalizeLegacyPropertyMarkConfig(parsedConfig, markType)
+        : parsedConfig;
 
     return {
       matchMode: config.matchMode ?? PathMatchMode.Layer,
-      layer: config.layer ?? 0,
-      regex: config.regex ?? "",
+      layer: config.layer ?? (isNewMark ? 0 : undefined),
+      regex: config.regex ?? (isNewMark ? "" : undefined),
       applyScope: config.applyScope ?? PathMarkApplyScope.MatchedOnly,
       propertyPool: config.pool,
       propertyId: config.propertyId,
       valueType: config.valueType ?? PropertyValueType.Fixed,
       fixedValue: config.fixedValue ?? "",
-      valueMatchMode: config.valueRegex ? PathMatchMode.Regex : PathMatchMode.Layer,
-      valueLayer: config.valueLayer ?? 0,
+      valueMatchMode:
+        config.valueRegexMatchesResourcePath || config.valueRegex
+          ? PathMatchMode.Regex
+          : PathMatchMode.Layer,
+      valueLayer: config.valueLayer ?? (isNewMark ? 0 : undefined),
       valueRegex: config.valueRegex ?? "",
+      valueRegexMatchesResourcePath: config.valueRegexMatchesResourcePath ?? false,
       fsTypeFilter: config.fsTypeFilter,
       extensions: config.extensions ?? [],
       extensionGroupIds: config.extensionGroupIds ?? [],
@@ -42,6 +115,25 @@ export const parseMarkConfig = (configJson?: string): MarkConfig => {
       valueLayer: 0,
     };
   }
+};
+
+export const hasValidPropertyValueExtractor = (
+  config: MarkConfig,
+  markType: PathMarkType,
+): boolean => {
+  if (markType !== PathMarkType.Property || config.valueType !== PropertyValueType.Dynamic) {
+    return true;
+  }
+
+  if (config.valueMatchMode === PathMatchMode.Regex) {
+    return Boolean(config.valueRegex?.trim());
+  }
+
+  return (
+    config.valueMatchMode === PathMatchMode.Layer &&
+    typeof config.valueLayer === "number" &&
+    Number.isFinite(config.valueLayer)
+  );
 };
 
 export const buildConfigJson = (config: MarkConfig, markType: PathMarkType): string => {
@@ -86,8 +178,14 @@ export const buildConfigJson = (config: MarkConfig, markType: PathMarkType): str
       propertyId: config.propertyId,
       valueType: config.valueType,
       fixedValue: config.fixedValue,
-      valueLayer: config.valueLayer,
+      valueLayer: config.valueMatchMode === PathMatchMode.Regex ? undefined : config.valueLayer,
       valueRegex: config.valueMatchMode === PathMatchMode.Regex ? config.valueRegex : undefined,
+      valueRegexMatchesResourcePath:
+        config.valueType === PropertyValueType.Dynamic &&
+        config.valueMatchMode === PathMatchMode.Regex &&
+        config.valueRegexMatchesResourcePath
+          ? true
+          : undefined,
       applyScope: config.applyScope ?? PathMarkApplyScope.MatchedOnly,
     });
   }

--- a/src/web/src/pages/path-mark-config/components/MarkDescription.tsx
+++ b/src/web/src/pages/path-mark-config/components/MarkDescription.tsx
@@ -5,6 +5,8 @@ import type { BakabaseAbstractionsModelsDomainPathMark } from "@/sdk/Api";
 import React, { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 
+import { normalizeLegacyPropertyMarkConfig } from "./MarkConfigModal/utils";
+
 import {
   PathMarkType,
   PropertyValueType,
@@ -26,11 +28,14 @@ const MarkDescription = ({ mark, className, label, priority }: Props) => {
 
   const config = useMemo(() => {
     try {
-      return JSON.parse(mark.configJson || "{}");
+      return normalizeLegacyPropertyMarkConfig(
+        JSON.parse(mark.configJson || "{}"),
+        mark.type as PathMarkType,
+      );
     } catch {
       return {};
     }
-  }, [mark.configJson]);
+  }, [mark.configJson, mark.type]);
 
   const getDescription = (): string => {
     try {
@@ -66,9 +71,11 @@ const MarkDescription = ({ mark, className, label, priority }: Props) => {
       const includesSubdirs = applyScope === PathMarkApplyScope.MatchedAndSubdirectories;
 
       if (matchMode === PathMatchMode.Layer) {
-        const layer = config.layer ?? 0;
+        const layer = config.layer;
 
-        if (layer === 0) {
+        if (layer === undefined || layer === null) {
+          parts.push(t("markDescription.invalid"));
+        } else if (layer === 0) {
           if (includesSubdirs) {
             parts.push(t("markDescription.layer.currentAndSubdirs"));
           } else {
@@ -88,13 +95,19 @@ const MarkDescription = ({ mark, className, label, priority }: Props) => {
           );
         }
       } else if (matchMode === PathMatchMode.Regex) {
-        const regex = config.regex ?? "";
-        const regexText = t("markDescription.regex", { regex });
+        const regex = config.regex;
 
-        parts.push(includesSubdirs ? `${regexText}${t("markDescription.andSubdirs")}` : regexText);
-      } else if (includesSubdirs) {
-        // No match mode but has subdirs scope
-        parts.push(t("markDescription.layer.currentAndSubdirs"));
+        if (regex) {
+          const regexText = t("markDescription.regex", { regex });
+
+          parts.push(
+            includesSubdirs ? `${regexText}${t("markDescription.andSubdirs")}` : regexText,
+          );
+        } else {
+          parts.push(t("markDescription.invalid"));
+        }
+      } else {
+        parts.push(t("markDescription.invalid"));
       }
 
       // For property marks - value info


### PR DESCRIPTION
## Summary

- restore the original root-and-descendants applicability of selectorless property marks emitted by the V220 migration across sync, preview, and resource-move hints
- preserve legacy resource-relative regex extraction while keeping modern property regexes and media-library marks on their existing semantics
- make future V220 conversions and editor saves persist explicit applicability, and reject incomplete dynamic extractors instead of silently falling back to layer zero
- drain queued search-index reads before mark-status writes to avoid SQLite reader/writer lock races and only report synchronization complete once search is current
- add end-to-end regressions for effect creation, UUID-backed single-choice values, immediate `In` filtering, option counts, effect cleanup, and media-library isolation

## Root cause

V220 stored a template property value extractor in `MatchMode` / `ValueLayer` or `ValueRegex`, but left both applicability selectors (`Layer` and `Regex`) empty. Migration-time effect seeding treated that shape as applying to every resource under the path, while the regular path-mark synchronizer treated it as matching nothing. Re-syncing therefore removed the effects and synchronized property values, leaving valid-looking options with zero resources and empty search results.

Legacy template regex extractors also matched each resource-relative path, so the compatibility path preserves that behavior explicitly instead of changing modern property regex semantics.

## Verification

- backend build: succeeded with 0 errors
- full `Bakabase.Tests`: 717 passed, 14 skipped because 7z is unavailable in the test container, 0 failed
- focused path-mark regression suite: 9 passed, 0 failed
- exact previously failing dynamic-property test: passed 10 consecutive runs in the Linux/x64 CI container
- frontend Vitest suite: 21 files / 287 tests passed
- frontend production build: succeeded
- changed frontend files: ESLint reported 0 errors

Fixes #1330