### PR TITLE
fix(path-mark): synchronize indexes with visible progress

### DIFF
--- a/.claude/rules/resource-search-index.md
+++ b/.claude/rules/resource-search-index.md
@@ -120,7 +120,7 @@ The caller (ResourceService) falls back to full-scan search at `ResourceService.
 
 ## Incremental Updates
 
-Resource changes are batched via Channel:
+Resource changes are batched via a single-reader Channel:
 
 ```csharp
 // Invalidate (update index)
@@ -132,7 +132,12 @@ RemoveResource(int resourceId)
 RemoveResources(IEnumerable<int> resourceIds)
 ```
 
-Batch processing: 100 items max, 500ms max delay.
+Each bulk notification is deduplicated and enqueued in bounded chunks of at most 4096
+resource IDs. The reader then coalesces adjacent chunks for up to 500ms or 4096 distinct
+resources, whichever comes first. This avoids repeating the full set of cache reads for
+every small batch while keeping memory and per-batch work bounded. If both update and remove
+notifications for one resource occur in the same barrier-delimited batch, remove wins, which
+preserves the previous batching semantics and prevents a stale row from being resurrected.
 
 `WaitForPendingUpdatesAsync` adds a FIFO barrier to the same channel. It completes only
 after every update queued before it has been applied; work queued after the barrier does

--- a/src/abstractions/Bakabase.Abstractions/Components/Localization/IBakabaseLocalizer.cs
+++ b/src/abstractions/Bakabase.Abstractions/Components/Localization/IBakabaseLocalizer.cs
@@ -110,9 +110,17 @@ public interface IBakabaseLocalizer
     // PathMark Sync
     string SyncPathMark_Collecting();
     string SyncPathMark_Collected(int count);
+    string SyncPathMark_CollectingPropertyEffects();
     string SyncPathMark_ProcessingResource(string path);
     string SyncPathMark_ProcessingProperty(string path);
+    string SyncPathMark_CollectingMediaLibraryEffects();
     string SyncPathMark_ProcessingMediaLibrary(string path);
+    string SyncPathMark_ComputingFinalState();
+    string SyncPathMark_ApplyingPropertyChanges();
+    string SyncPathMark_ApplyingMediaLibraryChanges();
+    string SyncPathMark_PersistingEffects();
+    string SyncPathMark_UpdatingSearchIndex();
+    string SyncPathMark_UpdatingMarkStatuses();
     string SyncPathMark_FindingRelated();
     string SyncPathMark_FoundRelated(int count);
     string SyncPathMark_EstablishingRelationships();

--- a/src/legacy/Bakabase.InsideWorld.Business/Components/BakabaseLocalizer.cs
+++ b/src/legacy/Bakabase.InsideWorld.Business/Components/BakabaseLocalizer.cs
@@ -410,9 +410,17 @@ namespace Bakabase.InsideWorld.Business.Components
         // PathMark Sync
         public string SyncPathMark_Collecting() => this[nameof(SyncPathMark_Collecting)];
         public string SyncPathMark_Collected(int count) => this[nameof(SyncPathMark_Collected), count];
+        public string SyncPathMark_CollectingPropertyEffects() => this[nameof(SyncPathMark_CollectingPropertyEffects)];
         public string SyncPathMark_ProcessingResource(string path) => this[nameof(SyncPathMark_ProcessingResource), path];
         public string SyncPathMark_ProcessingProperty(string path) => this[nameof(SyncPathMark_ProcessingProperty), path];
+        public string SyncPathMark_CollectingMediaLibraryEffects() => this[nameof(SyncPathMark_CollectingMediaLibraryEffects)];
         public string SyncPathMark_ProcessingMediaLibrary(string path) => this[nameof(SyncPathMark_ProcessingMediaLibrary), path];
+        public string SyncPathMark_ComputingFinalState() => this[nameof(SyncPathMark_ComputingFinalState)];
+        public string SyncPathMark_ApplyingPropertyChanges() => this[nameof(SyncPathMark_ApplyingPropertyChanges)];
+        public string SyncPathMark_ApplyingMediaLibraryChanges() => this[nameof(SyncPathMark_ApplyingMediaLibraryChanges)];
+        public string SyncPathMark_PersistingEffects() => this[nameof(SyncPathMark_PersistingEffects)];
+        public string SyncPathMark_UpdatingSearchIndex() => this[nameof(SyncPathMark_UpdatingSearchIndex)];
+        public string SyncPathMark_UpdatingMarkStatuses() => this[nameof(SyncPathMark_UpdatingMarkStatuses)];
         public string SyncPathMark_FindingRelated() => this[nameof(SyncPathMark_FindingRelated)];
         public string SyncPathMark_FoundRelated(int count) => this[nameof(SyncPathMark_FoundRelated), count];
         public string SyncPathMark_EstablishingRelationships() => this[nameof(SyncPathMark_EstablishingRelationships)];

--- a/src/legacy/Bakabase.InsideWorld.Business/Components/Search/Index/ResourceSearchIndexService.cs
+++ b/src/legacy/Bakabase.InsideWorld.Business/Components/Search/Index/ResourceSearchIndexService.cs
@@ -45,8 +45,10 @@ public class ResourceSearchIndexService : IResourceSearchIndexService
             SingleWriter = false
         });
 
-    // Batch update configuration
-    private const int BatchSize = 100;
+    // Batch update configuration. Bulk callers enqueue bounded chunks and the single
+    // reader adaptively coalesces adjacent chunks up to this many distinct resources.
+    // This keeps memory predictable while avoiding a full cache scan for every 100 IDs.
+    private const int MaxBatchResourceCount = 4096;
     private const int MaxDelayMs = 500;
     private const int MinBatchIntervalMs = 50;
     private const int MaxBatchAttempts = 3;
@@ -59,10 +61,11 @@ public class ResourceSearchIndexService : IResourceSearchIndexService
     private Exception? _unrecoveredIndexFailure;
     private readonly CancellationTokenSource _backgroundCts = new();
     private Task? _backgroundTask;
+    private long _pendingOperationCount;
 
     private abstract record IndexQueueItem;
 
-    private sealed record OperationQueueItem(IndexOperation Operation) : IndexQueueItem;
+    private sealed record OperationBatchQueueItem(IReadOnlyList<IndexOperation> Operations) : IndexQueueItem;
 
     private sealed record BarrierQueueItem(TaskCompletionSource Completion) : IndexQueueItem;
 
@@ -172,28 +175,22 @@ public class ResourceSearchIndexService : IResourceSearchIndexService
 
     public void InvalidateResource(int resourceId)
     {
-        EnqueueOperation(new IndexOperation(IndexOperationType.Update, resourceId));
+        EnqueueOperations(IndexOperationType.Update, [resourceId]);
     }
 
     public void InvalidateResources(IEnumerable<int> resourceIds)
     {
-        foreach (var resourceId in resourceIds)
-        {
-            EnqueueOperation(new IndexOperation(IndexOperationType.Update, resourceId));
-        }
+        EnqueueOperations(IndexOperationType.Update, resourceIds);
     }
 
     public void RemoveResource(int resourceId)
     {
-        EnqueueOperation(new IndexOperation(IndexOperationType.Remove, resourceId));
+        EnqueueOperations(IndexOperationType.Remove, [resourceId]);
     }
 
     public void RemoveResources(IEnumerable<int> resourceIds)
     {
-        foreach (var resourceId in resourceIds)
-        {
-            EnqueueOperation(new IndexOperation(IndexOperationType.Remove, resourceId));
-        }
+        EnqueueOperations(IndexOperationType.Remove, resourceIds);
     }
 
     public async Task WaitForPendingUpdatesAsync(CancellationToken ct = default)
@@ -210,16 +207,29 @@ public class ResourceSearchIndexService : IResourceSearchIndexService
         await completion.Task;
     }
 
-    private void EnqueueOperation(IndexOperation operation)
+    private void EnqueueOperations(IndexOperationType type, IEnumerable<int> resourceIds)
     {
-        if (!_operationChannel.Writer.TryWrite(new OperationQueueItem(operation)))
+        // Deduplicate one bulk notification before it reaches the channel. Very large
+        // notifications are split so no individual queue item or processing batch is
+        // unbounded; the reader can still merge adjacent chunks when IDs overlap.
+        foreach (var chunk in resourceIds.Distinct().Chunk(MaxBatchResourceCount))
         {
+            var operations = chunk.Select(resourceId => new IndexOperation(type, resourceId)).ToArray();
+            Interlocked.Add(ref _pendingOperationCount, operations.Length);
+
+            if (_operationChannel.Writer.TryWrite(new OperationBatchQueueItem(operations)))
+            {
+                continue;
+            }
+
+            Interlocked.Add(ref _pendingOperationCount, -operations.Length);
             _logger.LogError(
-                "Failed to enqueue {OperationType} operation for resource {ResourceId}",
-                operation.Type,
-                operation.ResourceId);
+                "Failed to enqueue {OperationType} operations for {ResourceCount} resources",
+                type,
+                operations.Length);
             MarkIndexUnavailable(new InvalidOperationException(
-                $"Failed to enqueue {operation.Type} operation for resource {operation.ResourceId}"));
+                $"Failed to enqueue {type} operations for {operations.Length} resources"));
+            return;
         }
     }
 
@@ -229,57 +239,118 @@ public class ResourceSearchIndexService : IResourceSearchIndexService
 
     private async Task ProcessOperationsAsync(CancellationToken ct)
     {
-        var batch = new List<IndexOperation>(BatchSize);
+        var batch = new Dictionary<int, IndexOperationType>(MaxBatchResourceCount);
+        IndexQueueItem? deferredItem = null;
 
         while (!ct.IsCancellationRequested)
         {
             try
             {
-                // Wait for the first operation
-                if (!await _operationChannel.Reader.WaitToReadAsync(ct))
+                IndexQueueItem? item;
+                if (deferredItem != null)
                 {
-                    break;
+                    item = deferredItem;
+                    deferredItem = null;
+                }
+                else
+                {
+                    // Wait for the first operation or barrier.
+                    if (!await _operationChannel.Reader.WaitToReadAsync(ct))
+                    {
+                        break;
+                    }
+
+                    if (!_operationChannel.Reader.TryRead(out item))
+                    {
+                        continue;
+                    }
                 }
 
                 batch.Clear();
                 var deadline = DateTime.UtcNow.AddMilliseconds(MaxDelayMs);
-                var processedOperations = false;
+                BarrierQueueItem? barrier = null;
+                var channelCompleted = false;
 
-                while (batch.Count < BatchSize &&
-                       DateTime.UtcNow < deadline &&
-                       _operationChannel.Reader.TryRead(out var item))
+                while (item != null)
                 {
-                    if (item is OperationQueueItem operationItem)
+                    if (item is BarrierQueueItem barrierItem)
                     {
-                        batch.Add(operationItem.Operation);
+                        // Never read or merge work beyond a barrier. Its completion therefore
+                        // remains an exact FIFO acknowledgement of the preceding prefix.
+                        barrier = barrierItem;
+                        break;
+                    }
+
+                    var operationItem = (OperationBatchQueueItem)item;
+                    var consumed = MergeOperations(batch, operationItem.Operations);
+                    Interlocked.Add(ref _pendingOperationCount, -consumed);
+
+                    if (consumed < operationItem.Operations.Count)
+                    {
+                        // This queue item exceeded the bounded number of distinct resources.
+                        // Keep its unconsumed suffix ahead of every item still in the channel.
+                        deferredItem = new OperationBatchQueueItem(operationItem.Operations
+                            .Skip(consumed)
+                            .ToArray());
+                        break;
+                    }
+
+                    if (batch.Count >= MaxBatchResourceCount)
+                    {
+                        break;
+                    }
+
+                    if (_operationChannel.Reader.TryRead(out item))
+                    {
                         continue;
                     }
 
-                    var barrier = (BarrierQueueItem)item;
-
-                    // A batch must never cross a barrier. Apply everything collected before
-                    // it, then complete the barrier before reading any subsequent work.
-                    if (batch.Count > 0)
+                    // Give adjacent small notifications a short bounded window to arrive.
+                    // A barrier arriving in this window is consumed on the next iteration and
+                    // ends the batch immediately.
+                    var remaining = deadline - DateTime.UtcNow;
+                    if (remaining <= TimeSpan.Zero)
                     {
-                        await ProcessBatchWithRetryAsync(batch, ct);
-                        batch.Clear();
-                        processedOperations = true;
+                        break;
                     }
 
-                    await CompleteBarrierAsync(barrier, ct);
-                    break;
+                    using var collectionCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+                    collectionCts.CancelAfter(remaining);
+                    try
+                    {
+                        if (!await _operationChannel.Reader.WaitToReadAsync(collectionCts.Token))
+                        {
+                            channelCompleted = true;
+                            break;
+                        }
+                    }
+                    catch (OperationCanceledException) when (!ct.IsCancellationRequested)
+                    {
+                        break;
+                    }
+
+                    _operationChannel.Reader.TryRead(out item);
                 }
 
                 if (batch.Count > 0)
                 {
                     await ProcessBatchWithRetryAsync(batch, ct);
-                    processedOperations = true;
                 }
 
-                if (processedOperations)
+                if (barrier != null)
                 {
-                    // Brief pause between batches to avoid resource overuse
+                    await CompleteBarrierAsync(barrier, ct);
+                }
+
+                if (batch.Count > 0)
+                {
+                    // Brief pause between batches to avoid resource overuse.
                     await Task.Delay(MinBatchIntervalMs, ct);
+                }
+
+                if (channelCompleted && deferredItem == null)
+                {
+                    break;
                 }
             }
             catch (OperationCanceledException) when (ct.IsCancellationRequested)
@@ -294,7 +365,38 @@ public class ResourceSearchIndexService : IResourceSearchIndexService
         }
     }
 
-    private async Task ProcessBatchWithRetryAsync(List<IndexOperation> operations, CancellationToken ct)
+    private static int MergeOperations(
+        Dictionary<int, IndexOperationType> batch,
+        IReadOnlyList<IndexOperation> operations)
+    {
+        var consumed = 0;
+        foreach (var operation in operations)
+        {
+            if (!batch.TryGetValue(operation.ResourceId, out var existingType))
+            {
+                if (batch.Count >= MaxBatchResourceCount)
+                {
+                    break;
+                }
+
+                batch[operation.ResourceId] = operation.Type;
+            }
+            else if (existingType == IndexOperationType.Remove || operation.Type == IndexOperationType.Remove)
+            {
+                // A removal wins within one barrier-delimited batch. Re-reading a resource
+                // that was removed in the same logical change can resurrect stale entries.
+                batch[operation.ResourceId] = IndexOperationType.Remove;
+            }
+
+            consumed++;
+        }
+
+        return consumed;
+    }
+
+    private async Task ProcessBatchWithRetryAsync(
+        IReadOnlyDictionary<int, IndexOperationType> operations,
+        CancellationToken ct)
     {
         Exception? lastError = null;
 
@@ -373,20 +475,19 @@ public class ResourceSearchIndexService : IResourceSearchIndexService
         }
     }
 
-    private async Task ProcessBatchAsync(List<IndexOperation> operations, CancellationToken ct)
+    private async Task ProcessBatchAsync(
+        IReadOnlyDictionary<int, IndexOperationType> operations,
+        CancellationToken ct)
     {
-        // Group by operation type and deduplicate
+        // Operations have already been deduplicated across adjacent queue items.
         var toRemove = operations
-            .Where(o => o.Type == IndexOperationType.Remove)
-            .Select(o => o.ResourceId)
-            .Distinct()
+            .Where(o => o.Value == IndexOperationType.Remove)
+            .Select(o => o.Key)
             .ToArray();
 
         var toUpdate = operations
-            .Where(o => o.Type == IndexOperationType.Update)
-            .Select(o => o.ResourceId)
-            .Distinct()
-            .Except(toRemove) // Don't update what we're removing
+            .Where(o => o.Value == IndexOperationType.Update)
+            .Select(o => o.Key)
             .ToArray();
 
         // Process removals first
@@ -415,6 +516,7 @@ public class ResourceSearchIndexService : IResourceSearchIndexService
     private async Task UpdateResourcesIndexAsync(int[] resourceIds, CancellationToken ct)
     {
         using var scope = _scopeFactory.CreateScope();
+        var resourceIdSet = resourceIds.ToHashSet();
 
         try
         {
@@ -432,7 +534,7 @@ public class ResourceSearchIndexService : IResourceSearchIndexService
                 .GetRequiredService<IMediaLibraryResourceMappingService>();
 
             var customPropertyValues = await customPropertyValueService
-                .GetAll(x => resourceIds.Contains(x.ResourceId),
+                .GetAll(x => resourceIdSet.Contains(x.ResourceId),
                     InsideWorld.Models.Constants.AdditionalItems.CustomPropertyValueAdditionalItem.None, false);
             var customPropertyService = scope.ServiceProvider
                 .GetRequiredService<ICustomPropertyService>();
@@ -440,8 +542,8 @@ public class ResourceSearchIndexService : IResourceSearchIndexService
             var propertyMap = customProperties.ToDictionary(p => p.Id, p => p.ToProperty());
 
             var reservedPropertyValues = await reservedPropertyValueService
-                .GetAll(x => resourceIds.Contains(x.ResourceId));
-            var resourceDbModels = await resourceOrm.GetAllDbModels(x => resourceIds.Contains(x.Id));
+                .GetAll(x => resourceIdSet.Contains(x.ResourceId));
+            var resourceDbModels = await resourceOrm.GetAllDbModels(x => resourceIdSet.Contains(x.Id));
             var dbResourceMap = resourceDbModels.ToDictionary(r => r.Id, r => r);
             var mediaLibraryMappings = await mediaLibraryResourceMappingService
                 .GetMediaLibraryIdsByResourceIds(resourceIds);
@@ -1241,8 +1343,8 @@ public class ResourceSearchIndexService : IResourceSearchIndexService
             Version = _index.Version,
             LastUpdatedAt = _index.LastUpdatedAt,
             TotalResourceCount = _index.AllResourceIds.Count,
-            // CanCount guard: the single-reader operation channel does not support Count.
-            PendingUpdateCount = _operationChannel.Reader.CanCount ? _operationChannel.Reader.Count : 0,
+            PendingUpdateCount = (int)Math.Min(int.MaxValue,
+                Math.Max(0, Interlocked.Read(ref _pendingOperationCount))),
             IndexSizes = new Dictionary<string, int>
             {
                 ["ValueIndex"] = _index.GetValueIndexEntryCount(),

--- a/src/legacy/Bakabase.InsideWorld.Business/Resources/SharedResource.resx
+++ b/src/legacy/Bakabase.InsideWorld.Business/Resources/SharedResource.resx
@@ -639,14 +639,38 @@ The version of lux is not limited.</value>
   <data name="SyncPathMark_Collected" xml:space="preserve">
     <value>Collected {0} path marks</value>
   </data>
+  <data name="SyncPathMark_CollectingPropertyEffects" xml:space="preserve">
+    <value>Collecting property effects...</value>
+  </data>
   <data name="SyncPathMark_ProcessingResource" xml:space="preserve">
     <value>Processing resource: {0}</value>
   </data>
   <data name="SyncPathMark_ProcessingProperty" xml:space="preserve">
     <value>Processing property: {0}</value>
   </data>
+  <data name="SyncPathMark_CollectingMediaLibraryEffects" xml:space="preserve">
+    <value>Collecting media library effects...</value>
+  </data>
   <data name="SyncPathMark_ProcessingMediaLibrary" xml:space="preserve">
     <value>Processing media library: {0}</value>
+  </data>
+  <data name="SyncPathMark_ComputingFinalState" xml:space="preserve">
+    <value>Computing final state...</value>
+  </data>
+  <data name="SyncPathMark_ApplyingPropertyChanges" xml:space="preserve">
+    <value>Applying property changes...</value>
+  </data>
+  <data name="SyncPathMark_ApplyingMediaLibraryChanges" xml:space="preserve">
+    <value>Applying media library changes...</value>
+  </data>
+  <data name="SyncPathMark_PersistingEffects" xml:space="preserve">
+    <value>Persisting effects...</value>
+  </data>
+  <data name="SyncPathMark_UpdatingSearchIndex" xml:space="preserve">
+    <value>Waiting for the resource search index to update...</value>
+  </data>
+  <data name="SyncPathMark_UpdatingMarkStatuses" xml:space="preserve">
+    <value>Updating mark statuses...</value>
   </data>
   <data name="SyncPathMark_FindingRelated" xml:space="preserve">
     <value>Finding related marks</value>

--- a/src/legacy/Bakabase.InsideWorld.Business/Resources/SharedResource.resx
+++ b/src/legacy/Bakabase.InsideWorld.Business/Resources/SharedResource.resx
@@ -600,6 +600,27 @@ The version of lux is not limited.</value>
   <data name="BTask_Description_ResourceProfileIndex" xml:space="preserve">
     <value>Build the index between resources and profiles to speed up matching. Automatically rebuilds when resources or profiles change.</value>
   </data>
+  <data name="ResourceProfileIndex_LoadingIncrementalUpdates" xml:space="preserve">
+    <value>Collecting resource profile index updates...</value>
+  </data>
+  <data name="ResourceProfileIndex_WaitingForSearchIndex" xml:space="preserve">
+    <value>Waiting for resource search index updates...</value>
+  </data>
+  <data name="ResourceProfileIndex_ProcessingProfileInvalidations" xml:space="preserve">
+    <value>Updating resource profiles {0}/{1}...</value>
+  </data>
+  <data name="ResourceProfileIndex_InvalidatingPlayableFileCaches" xml:space="preserve">
+    <value>Invalidating playable-file caches for {0} resources...</value>
+  </data>
+  <data name="ResourceProfileIndex_LoadingProfilesForResources" xml:space="preserve">
+    <value>Loading profiles for {0} changed resources...</value>
+  </data>
+  <data name="ResourceProfileIndex_MatchingProfilesForResources" xml:space="preserve">
+    <value>Matching profiles {0}/{1} for {2} changed resources...</value>
+  </data>
+  <data name="ResourceProfileIndex_UpdatingResourceMappings" xml:space="preserve">
+    <value>Updating profile mappings for {0} resources...</value>
+  </data>
   <data name="BTask_Name_SearchIndex" xml:space="preserve">
     <value>Build search index</value>
   </data>

--- a/src/legacy/Bakabase.InsideWorld.Business/Resources/SharedResource.zh-Hans.resx
+++ b/src/legacy/Bakabase.InsideWorld.Business/Resources/SharedResource.zh-Hans.resx
@@ -600,6 +600,27 @@
   <data name="BTask_Description_ResourceProfileIndex" xml:space="preserve">
     <value>构建资源与配置的匹配索引以加速匹配。资源或配置发生变更时会自动重新构建。</value>
   </data>
+  <data name="ResourceProfileIndex_LoadingIncrementalUpdates" xml:space="preserve">
+    <value>正在收集资源配置索引更新...</value>
+  </data>
+  <data name="ResourceProfileIndex_WaitingForSearchIndex" xml:space="preserve">
+    <value>正在等待资源搜索索引更新...</value>
+  </data>
+  <data name="ResourceProfileIndex_ProcessingProfileInvalidations" xml:space="preserve">
+    <value>正在更新资源配置 {0}/{1}...</value>
+  </data>
+  <data name="ResourceProfileIndex_InvalidatingPlayableFileCaches" xml:space="preserve">
+    <value>正在清除 {0} 个资源的可播放文件缓存...</value>
+  </data>
+  <data name="ResourceProfileIndex_LoadingProfilesForResources" xml:space="preserve">
+    <value>正在为 {0} 个变更资源加载配置...</value>
+  </data>
+  <data name="ResourceProfileIndex_MatchingProfilesForResources" xml:space="preserve">
+    <value>正在为 {2} 个变更资源匹配配置 {0}/{1}...</value>
+  </data>
+  <data name="ResourceProfileIndex_UpdatingResourceMappings" xml:space="preserve">
+    <value>正在更新 {0} 个资源的配置映射...</value>
+  </data>
   <data name="BTask_Name_SearchIndex" xml:space="preserve">
     <value>构建搜索索引</value>
   </data>

--- a/src/legacy/Bakabase.InsideWorld.Business/Resources/SharedResource.zh-Hans.resx
+++ b/src/legacy/Bakabase.InsideWorld.Business/Resources/SharedResource.zh-Hans.resx
@@ -639,14 +639,38 @@
   <data name="SyncPathMark_Collected" xml:space="preserve">
     <value>已收集 {0} 个路径标记</value>
   </data>
+  <data name="SyncPathMark_CollectingPropertyEffects" xml:space="preserve">
+    <value>正在计算属性标记结果...</value>
+  </data>
   <data name="SyncPathMark_ProcessingResource" xml:space="preserve">
     <value>处理资源: {0}</value>
   </data>
   <data name="SyncPathMark_ProcessingProperty" xml:space="preserve">
     <value>处理属性: {0}</value>
   </data>
+  <data name="SyncPathMark_CollectingMediaLibraryEffects" xml:space="preserve">
+    <value>正在计算媒体库标记结果...</value>
+  </data>
   <data name="SyncPathMark_ProcessingMediaLibrary" xml:space="preserve">
     <value>处理媒体库: {0}</value>
+  </data>
+  <data name="SyncPathMark_ComputingFinalState" xml:space="preserve">
+    <value>正在计算最终状态...</value>
+  </data>
+  <data name="SyncPathMark_ApplyingPropertyChanges" xml:space="preserve">
+    <value>正在应用属性变更...</value>
+  </data>
+  <data name="SyncPathMark_ApplyingMediaLibraryChanges" xml:space="preserve">
+    <value>正在应用媒体库变更...</value>
+  </data>
+  <data name="SyncPathMark_PersistingEffects" xml:space="preserve">
+    <value>正在保存标记计算结果...</value>
+  </data>
+  <data name="SyncPathMark_UpdatingSearchIndex" xml:space="preserve">
+    <value>正在等待资源搜索索引更新...</value>
+  </data>
+  <data name="SyncPathMark_UpdatingMarkStatuses" xml:space="preserve">
+    <value>正在更新标记状态...</value>
   </data>
   <data name="SyncPathMark_FindingRelated" xml:space="preserve">
     <value>查找关联标记中</value>

--- a/src/legacy/Bakabase.InsideWorld.Business/Services/PathMarkSyncService.cs
+++ b/src/legacy/Bakabase.InsideWorld.Business/Services/PathMarkSyncService.cs
@@ -96,6 +96,7 @@ public class PathMarkSyncService : ScopedService
     /// 2. Phase 2: Compute Final State - Use Combine to merge effects into final values
     /// 3. Phase 3: Apply Changes - Create/update/delete property values and media library mappings
     /// 4. Phase 4: Persist Effects - Save effects to DB
+    /// 5. Phase 5: Wait for the resource search index to catch up before marking the sync complete
     ///
     /// All resources are loaded as context for effect computation.
     ///
@@ -207,7 +208,8 @@ public class PathMarkSyncService : ScopedService
             // ===== Phase 1: Collect Effects (5-30%) =====
 
             // 1a. Collect property effects
-            await ReportProgress(onProgressChange, onProcessChange, 5, "Collecting property effects...");
+            await ReportProgress(onProgressChange, onProcessChange, 5,
+                _localizer.SyncPathMark_CollectingPropertyEffects());
             for (var i = 0; i < activePropertyMarks.Count; i++)
             {
                 ct.ThrowIfCancellationRequested();
@@ -234,7 +236,8 @@ public class PathMarkSyncService : ScopedService
             }
 
             // 1b. Collect media library effects
-            await ReportProgress(onProgressChange, onProcessChange, 20, "Collecting media library effects...");
+            await ReportProgress(onProgressChange, onProcessChange, 20,
+                _localizer.SyncPathMark_CollectingMediaLibraryEffects());
             for (var i = 0; i < activeMediaLibraryMarks.Count; i++)
             {
                 ct.ThrowIfCancellationRequested();
@@ -261,17 +264,20 @@ public class PathMarkSyncService : ScopedService
             }
 
             // ===== Phase 2: Compute Final State (30-50%) =====
-            await ReportProgress(onProgressChange, onProcessChange, 30, "Computing final state...");
+            await ReportProgress(onProgressChange, onProcessChange, 30,
+                _localizer.SyncPathMark_ComputingFinalState());
             await ComputeFinalPropertyState(ctx);
             await ComputeFinalMediaLibraryState(ctx);
 
             // ===== Phase 3: Apply Changes (50-80%) =====
-            await ReportProgress(onProgressChange, onProcessChange, 50, "Applying property changes...");
+            await ReportProgress(onProgressChange, onProcessChange, 50,
+                _localizer.SyncPathMark_ApplyingPropertyChanges());
             var propertyResult = await ApplyPropertyChanges(ctx, ct);
             result.PropertiesApplied = propertyResult.Applied;
             result.PropertiesDeleted = propertyResult.Deleted;
 
-            await ReportProgress(onProgressChange, onProcessChange, 65, "Applying media library changes...");
+            await ReportProgress(onProgressChange, onProcessChange, 65,
+                _localizer.SyncPathMark_ApplyingMediaLibraryChanges());
             var mappingResult = await ApplyMediaLibraryChanges(ctx, ct);
             result.MediaLibraryMappingsCreated = mappingResult.Created;
             result.MediaLibraryMappingsDeleted = mappingResult.Deleted;
@@ -294,18 +300,33 @@ public class PathMarkSyncService : ScopedService
                     affectedMediaLibraryIds.Count);
             }
 
-            // ===== Phase 4: Persist Effects (80-95%) =====
-            await ReportProgress(onProgressChange, onProcessChange, 80, "Persisting effects...");
+            // ===== Phase 4: Persist Effects (80-90%) =====
+            await ReportProgress(onProgressChange, onProcessChange, 80,
+                _localizer.SyncPathMark_PersistingEffects());
             await ComputeEffectDiff(ctx);
-            await PersistEffects(ctx);
+            await PersistEffects(ctx, onProgressChange, ct);
 
-            // ===== Cleanup (95-100%) =====
+            // ===== Phase 5: Wait for Search Index (90-95%) =====
             // Property and mapping writes enqueue background index reads through a separate
             // DbContext. Drain those reads before writing mark statuses so SQLite does not see
             // a reader/writer race, and only report the marks as synced once search is current.
-            await _resourceSearchIndexService.WaitForPendingUpdatesAsync(ct);
+            await ReportProgress(onProgressChange, onProcessChange, 90,
+                _localizer.SyncPathMark_UpdatingSearchIndex());
+            var indexBarrierSw = Stopwatch.StartNew();
+            try
+            {
+                await _resourceSearchIndexService.WaitForPendingUpdatesAsync(ct);
+            }
+            finally
+            {
+                indexBarrierSw.Stop();
+                _logger.LogInformation("[Sync] Resource search index barrier took {ElapsedMs}ms",
+                    indexBarrierSw.ElapsedMilliseconds);
+            }
 
-            await ReportProgress(onProgressChange, onProcessChange, 95, "Updating mark statuses...");
+            // ===== Cleanup (95-100%) =====
+            await ReportProgress(onProgressChange, onProcessChange, 95,
+                _localizer.SyncPathMark_UpdatingMarkStatuses());
             await BatchUpdateMarkStatuses(ctx, marksToDelete);
 
             await ReportProgress(onProgressChange, onProcessChange, 100, _localizer.SyncPathMark_Complete());
@@ -1127,36 +1148,57 @@ public class PathMarkSyncService : ScopedService
     /// <summary>
     /// Persists effect changes to database.
     /// </summary>
-    private async Task PersistEffects(SyncContext ctx)
+    private async Task PersistEffects(
+        SyncContext ctx,
+        Func<int, Task>? onProgressChange,
+        CancellationToken ct)
     {
         var sw = Stopwatch.StartNew();
+        var addBatches = ctx.PropertyEffectsToAdd.Chunk(BatchSize).ToList();
+        var updateBatches = ctx.PropertyEffectsToUpdate.Values.Chunk(BatchSize).ToList();
+        var operationCount = addBatches.Count + updateBatches.Count +
+                             (ctx.PropertyEffectIdsToDelete.Count > 0 ? 1 : 0);
+        var completedOperations = 0;
+
+        async Task ReportOperationCompleted()
+        {
+            completedOperations++;
+            if (onProgressChange != null)
+            {
+                await onProgressChange(80 + (int)(10.0 * completedOperations / operationCount));
+            }
+        }
 
         // Add new property effects
-        if (ctx.PropertyEffectsToAdd.Count > 0)
+        if (addBatches.Count > 0)
         {
-            var batches = ctx.PropertyEffectsToAdd.Chunk(BatchSize).ToList();
-            for (var i = 0; i < batches.Count; i++)
+            for (var i = 0; i < addBatches.Count; i++)
             {
-                await _effectService.AddPropertyEffects(batches[i]);
-                if (i < batches.Count - 1) await Task.Delay(5);
+                ct.ThrowIfCancellationRequested();
+                await _effectService.AddPropertyEffects(addBatches[i]);
+                await ReportOperationCompleted();
+                if (i < addBatches.Count - 1) await Task.Delay(5, ct);
             }
         }
 
         // Update same-key effects and lazily normalized V220 effects.
-        if (ctx.PropertyEffectsToUpdate.Count > 0)
+        if (updateBatches.Count > 0)
         {
-            var batches = ctx.PropertyEffectsToUpdate.Values.Chunk(BatchSize).ToList();
-            for (var i = 0; i < batches.Count; i++)
+            for (var i = 0; i < updateBatches.Count; i++)
             {
-                await _effectService.UpdatePropertyEffects(batches[i]);
-                if (i < batches.Count - 1) await Task.Delay(5);
+                ct.ThrowIfCancellationRequested();
+                await _effectService.UpdatePropertyEffects(updateBatches[i]);
+                await ReportOperationCompleted();
+                if (i < updateBatches.Count - 1) await Task.Delay(5, ct);
             }
         }
 
         // Delete stale property effects
         if (ctx.PropertyEffectIdsToDelete.Count > 0)
         {
+            ct.ThrowIfCancellationRequested();
             await _effectService.DeletePropertyEffects(ctx.PropertyEffectIdsToDelete);
+            await ReportOperationCompleted();
         }
 
         sw.Stop();

--- a/src/legacy/Bakabase.InsideWorld.Business/Services/ResourceProfileIndexService.cs
+++ b/src/legacy/Bakabase.InsideWorld.Business/Services/ResourceProfileIndexService.cs
@@ -41,7 +41,8 @@ public class ResourceProfileIndexService : IResourceProfileIndexService
     // Pending invalidation queues
     private readonly ConcurrentQueue<int> _pendingResourceInvalidations = new();
     private readonly ConcurrentQueue<int> _pendingProfileInvalidations = new();
-    private volatile bool _pendingFullRebuild;
+    // Int32 so consuming a rebuild request cannot overwrite a concurrent request.
+    private int _pendingFullRebuild;
 
     // Debounce timer
     private Timer? _debounceTimer;
@@ -148,13 +149,13 @@ public class ResourceProfileIndexService : IResourceProfileIndexService
 
     public void InvalidateAllProfiles()
     {
-        _pendingFullRebuild = true;
+        Volatile.Write(ref _pendingFullRebuild, 1);
         ScheduleUpdate();
     }
 
     public void TriggerFullRebuild()
     {
-        _pendingFullRebuild = true;
+        Volatile.Write(ref _pendingFullRebuild, 1);
         ScheduleUpdate();
     }
 
@@ -188,9 +189,17 @@ public class ResourceProfileIndexService : IResourceProfileIndexService
         // Check if there's already a pending task
         if (_taskManager.IsPending(TaskId))
         {
-            // Task is already running or queued, it will pick up pending invalidations
+            // The active task may already have drained its snapshot. Keep checking until it
+            // finishes so invalidations arriving during its run cannot remain queued forever.
+            if (HasPendingUpdates())
+            {
+                ScheduleUpdate();
+            }
+
             return;
         }
+
+        if (!HasPendingUpdates()) return;
 
         var builder = BTaskBuilder.Create(TaskId)
             .Named(() => _localizer.BTask_Name("ResourceProfileIndex"))
@@ -211,18 +220,47 @@ public class ResourceProfileIndexService : IResourceProfileIndexService
             var sp = scope.ServiceProvider;
             var resourceProfileService = sp.GetRequiredService<IResourceProfileService>();
             var resourceService = sp.GetRequiredService<IResourceService>();
+            var resourceSearchIndexService = sp.GetRequiredService<IResourceSearchIndexService>();
 
             // Check if full rebuild is needed
-            if (_pendingFullRebuild || !_isReady)
+            if (Volatile.Read(ref _pendingFullRebuild) != 0 || !_isReady)
             {
-                _pendingFullRebuild = false;
-                // Clear partial invalidation queues since we're doing full rebuild
+                // Consume the request before taking the queue snapshot. A rebuild requested
+                // after this exchange remains pending for a follow-up task instead of being
+                // overwritten when this rebuild finishes.
+                Interlocked.Exchange(ref _pendingFullRebuild, 0);
+
+                // This rebuild supersedes the invalidations already queued. Drain them before
+                // placing the search-index barrier so changes arriving afterwards remain queued
+                // for the next task rather than being discarded after the barrier snapshot.
                 while (_pendingResourceInvalidations.TryDequeue(out _)) { }
                 while (_pendingProfileInvalidations.TryDequeue(out _)) { }
 
-                await FullRebuild(resourceProfileService, resourceService, args);
+                try
+                {
+                    await ReportIncrementalProgress(
+                        args,
+                        1,
+                        "ResourceProfileIndex_WaitingForSearchIndex");
+                    await WaitForSearchIndexOrFallback(resourceSearchIndexService, args.CancellationToken);
+                    await FullRebuild(resourceProfileService, resourceService, args);
+                }
+                catch
+                {
+                    // A cancelled or failed rebuild did not establish a complete profile index.
+                    // Keep the request available for an explicit restart (cancellation) or the
+                    // automatically scheduled retry (other failures).
+                    Volatile.Write(ref _pendingFullRebuild, 1);
+                    throw;
+                }
+
                 return;
             }
+
+            await ReportIncrementalProgress(
+                args,
+                1,
+                "ResourceProfileIndex_LoadingIncrementalUpdates");
 
             // Process profile invalidations first (they may require re-evaluating all resources)
             var profilesToInvalidate = new HashSet<int>();
@@ -231,26 +269,123 @@ public class ResourceProfileIndexService : IResourceProfileIndexService
                 profilesToInvalidate.Add(profileId);
             }
 
-            if (profilesToInvalidate.Count > 0)
-            {
-                await ProcessProfileInvalidations(profilesToInvalidate, resourceProfileService, resourceService, args);
-            }
-
-            // Process resource invalidations
             var resourcesToInvalidate = new HashSet<int>();
             while (_pendingResourceInvalidations.TryDequeue(out var resourceId))
             {
                 resourcesToInvalidate.Add(resourceId);
             }
 
-            if (resourcesToInvalidate.Count > 0)
+            if (profilesToInvalidate.Count == 0 && resourcesToInvalidate.Count == 0) return;
+
+            await ReportIncrementalProgress(
+                args,
+                3,
+                "ResourceProfileIndex_WaitingForSearchIndex");
+
+            // Resource data changes enqueue both search-index and profile-index work. Matching
+            // profiles before the search-index queue reaches this snapshot can cache stale
+            // results, so place a FIFO barrier immediately before evaluating any profile.
+            try
             {
-                await ProcessResourceInvalidations(resourcesToInvalidate, resourceProfileService, resourceService, args);
+                await WaitForSearchIndexOrFallback(resourceSearchIndexService, args.CancellationToken);
             }
+            catch (OperationCanceledException) when (args.CancellationToken.IsCancellationRequested)
+            {
+                RequeueInvalidations(profilesToInvalidate, resourcesToInvalidate, false);
+                throw;
+            }
+
+            try
+            {
+                if (profilesToInvalidate.Count > 0)
+                {
+                    await ProcessProfileInvalidations(
+                        profilesToInvalidate,
+                        resourceProfileService,
+                        resourceService,
+                        args,
+                        5,
+                        resourcesToInvalidate.Count > 0 ? 45 : 95);
+                }
+
+                if (resourcesToInvalidate.Count > 0)
+                {
+                    await ProcessResourceInvalidations(
+                        resourcesToInvalidate,
+                        resourceProfileService,
+                        resourceService,
+                        args,
+                        profilesToInvalidate.Count > 0 ? 50 : 5,
+                        95);
+                }
+            }
+            catch (OperationCanceledException) when (args.CancellationToken.IsCancellationRequested)
+            {
+                RequeueInvalidations(profilesToInvalidate, resourcesToInvalidate, false);
+                throw;
+            }
+            catch
+            {
+                // Fallible asynchronous reads and cache persistence finish before either
+                // direction publishes its copy-on-write mapping, so this snapshot is retryable.
+                RequeueInvalidations(profilesToInvalidate, resourcesToInvalidate, true);
+                throw;
+            }
+        }
+        catch (OperationCanceledException) when (args.CancellationToken.IsCancellationRequested)
+        {
+            throw;
         }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Error processing ResourceProfile index updates");
+            if (HasPendingUpdates()) ScheduleUpdate();
+            throw;
+        }
+    }
+
+    private void RequeueInvalidations(
+        IEnumerable<int> profileIds,
+        IEnumerable<int> resourceIds,
+        bool scheduleUpdate)
+    {
+        foreach (var profileId in profileIds)
+        {
+            _pendingProfileInvalidations.Enqueue(profileId);
+        }
+
+        foreach (var resourceId in resourceIds)
+        {
+            _pendingResourceInvalidations.Enqueue(resourceId);
+        }
+
+        if (scheduleUpdate) ScheduleUpdate();
+    }
+
+    private bool HasPendingUpdates() =>
+        Volatile.Read(ref _pendingFullRebuild) != 0 ||
+        !_pendingProfileInvalidations.IsEmpty ||
+        !_pendingResourceInvalidations.IsEmpty;
+
+    private async Task WaitForSearchIndexOrFallback(
+        IResourceSearchIndexService resourceSearchIndexService,
+        CancellationToken ct)
+    {
+        try
+        {
+            await resourceSearchIndexService.WaitForPendingUpdatesAsync(ct);
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            // A failed incremental search-index batch marks that index unavailable. Resource
+            // searches then deliberately fall back to a full scan, which is still a correct
+            // source for rebuilding profile mappings and avoids an endless retry loop here.
+            _logger.LogWarning(ex,
+                "Resource search index barrier failed; ResourceProfile matching will use the full-scan fallback");
         }
     }
 
@@ -365,63 +500,115 @@ public class ResourceProfileIndexService : IResourceProfileIndexService
         HashSet<int> profileIds,
         IResourceProfileService resourceProfileService,
         IResourceService resourceService,
-        BTaskArgs args)
+        BTaskArgs args,
+        int progressStart,
+        int progressEnd)
     {
         _logger.LogDebug("Processing {Count} profile invalidations", profileIds.Count);
+
+        await ReportIncrementalProgress(
+            args,
+            progressStart,
+            "ResourceProfileIndex_ProcessingProfileInvalidations",
+            0,
+            profileIds.Count);
 
         // Get current profiles
         var allProfiles = await resourceProfileService.GetAll();
         var profileMap = allProfiles.ToDictionary(p => p.Id);
 
-        // Update priorities
-        foreach (var profile in allProfiles)
-        {
-            _profilePriorities[profile.Id] = profile.Priority;
-        }
-
         // Resources touched by a profile add/edit/delete: their effective playable-file options
         // may have changed (the profile gained/lost them, or its playable rules were edited), so
         // any cached playable-file result must be invalidated to be re-discovered on next access.
         var affectedResourceIds = new HashSet<int>();
+        var rebuiltResourceIdsByProfile = new Dictionary<int, HashSet<int>?>(profileIds.Count);
+        var processedProfiles = 0;
+        var processingProgressEnd = Math.Max(progressStart, progressEnd - 5);
 
+        // Resolve every new matching set before mutating either direction of the cache. If one
+        // search fails, the queued snapshot can be retried without having lost the old mapping
+        // needed to invalidate playable-file caches correctly.
         foreach (var profileId in profileIds)
         {
-            args.CancellationToken.ThrowIfCancellationRequested();
+            await args.YieldAsync();
 
-            // Remove old entries for this profile
-            if (_profileToResources.TryRemove(profileId, out var oldResourceIds))
-            {
-                foreach (var resourceId in oldResourceIds)
-                {
-                    RemoveProfileFromResource(resourceId, profileId);
-                    affectedResourceIds.Add(resourceId);
-                }
-            }
-
-            // If profile still exists, rebuild its index
             if (profileMap.TryGetValue(profileId, out var profile))
             {
                 // Use profile.Search directly to bypass index cache and avoid circular dependency
-                var matchingResourceIds = await resourceProfileService.GetMatchingResourceIds(profile.Search);
-                _profileToResources[profileId] = matchingResourceIds;
+                rebuiltResourceIdsByProfile[profileId] =
+                    await resourceProfileService.GetMatchingResourceIds(profile.Search);
+            }
+            else
+            {
+                rebuiltResourceIdsByProfile[profileId] = null;
+            }
 
-                foreach (var resourceId in matchingResourceIds)
+            processedProfiles++;
+            await ReportIncrementalProgress(
+                args,
+                ScaleProgress(progressStart, processingProgressEnd, processedProfiles, profileIds.Count),
+                "ResourceProfileIndex_ProcessingProfileInvalidations",
+                processedProfiles,
+                profileIds.Count);
+        }
+
+        var oldResourceIdsByProfile = profileIds.ToDictionary(
+            profileId => profileId,
+            profileId => _profileToResources.GetValueOrDefault(profileId) ?? new HashSet<int>());
+        foreach (var profileId in profileIds)
+        {
+            affectedResourceIds.UnionWith(oldResourceIdsByProfile[profileId]);
+            if (rebuiltResourceIdsByProfile[profileId] is { } newResourceIds)
+            {
+                affectedResourceIds.UnionWith(newResourceIds);
+            }
+        }
+
+        // Clear derived data before publishing the new mapping. If cache persistence fails,
+        // no mapping has been changed yet and retrying the queued snapshot remains lossless.
+        if (affectedResourceIds.Count > 0)
+        {
+            await ReportIncrementalProgress(
+                args,
+                Math.Max(processingProgressEnd, progressEnd - 2),
+                "ResourceProfileIndex_InvalidatingPlayableFileCaches",
+                affectedResourceIds.Count);
+            await resourceService.DeleteResourceCacheByResourceIdsAndCacheType(
+                affectedResourceIds, ResourceCacheType.PlayableFiles);
+        }
+
+        await args.YieldAsync();
+        await ReportIncrementalProgress(
+            args,
+            progressEnd,
+            "ResourceProfileIndex_UpdatingResourceMappings",
+            affectedResourceIds.Count);
+
+        foreach (var profileId in profileIds)
+        {
+            var oldResourceIds = oldResourceIdsByProfile[profileId];
+            var newResourceIds = rebuiltResourceIdsByProfile[profileId];
+
+            foreach (var resourceId in oldResourceIds)
+            {
+                RemoveProfileFromResource(resourceId, profileId);
+            }
+
+            if (newResourceIds != null)
+            {
+                _profilePriorities[profileId] = profileMap[profileId].Priority;
+                _profileToResources[profileId] = newResourceIds;
+
+                foreach (var resourceId in newResourceIds)
                 {
                     AddProfileToResource(resourceId, profileId);
-                    affectedResourceIds.Add(resourceId);
                 }
             }
             else
             {
-                // Profile was deleted, remove from priority cache
+                _profileToResources.TryRemove(profileId, out _);
                 _profilePriorities.TryRemove(profileId, out _);
             }
-        }
-
-        if (affectedResourceIds.Count > 0)
-        {
-            await resourceService.DeleteResourceCacheByResourceIdsAndCacheType(
-                affectedResourceIds, ResourceCacheType.PlayableFiles);
         }
     }
 
@@ -429,11 +616,31 @@ public class ResourceProfileIndexService : IResourceProfileIndexService
         HashSet<int> resourceIds,
         IResourceProfileService resourceProfileService,
         IResourceService resourceService,
-        BTaskArgs args)
+        BTaskArgs args,
+        int progressStart,
+        int progressEnd)
     {
         _logger.LogDebug("Processing {Count} resource invalidations", resourceIds.Count);
 
+        await ReportIncrementalProgress(
+            args,
+            progressStart,
+            "ResourceProfileIndex_LoadingProfilesForResources",
+            resourceIds.Count);
+
         var allProfiles = await resourceProfileService.GetAll();
+
+        foreach (var profile in allProfiles)
+        {
+            _profilePriorities[profile.Id] = profile.Priority;
+        }
+
+        var activeProfileIds = allProfiles.Select(p => p.Id).ToHashSet();
+        var oldProfileIdsByResource = resourceIds.ToDictionary(
+            resourceId => resourceId,
+            resourceId => _resourceToProfiles.TryGetValue(resourceId, out var existing)
+                ? existing
+                : Array.Empty<int>());
 
         // Resources whose matching-profile set actually changed. Their effective playable-file
         // options come from the highest-priority matching profile, so a change here can make a
@@ -444,44 +651,115 @@ public class ResourceProfileIndexService : IResourceProfileIndexService
         // invalidate that entry so the next access re-discovers from the (now resolvable) profile.
         var matchingChangedResourceIds = new HashSet<int>();
 
+        // Evaluate each profile exactly once. The previous resource-major loop executed the same
+        // full matching search once per invalidated resource, even though every result was the
+        // complete set of resources matching that profile.
+        var matchingProfileIdsByResource = resourceIds.ToDictionary(id => id, _ => new List<int>());
+        var affectedMatchesByProfile = new Dictionary<int, HashSet<int>>(allProfiles.Count);
+        var processedProfiles = 0;
+        var matchingProgressEnd = Math.Max(progressStart, progressEnd - 10);
+
+        foreach (var profile in allProfiles)
+        {
+            await args.YieldAsync();
+
+            // Use profile.Search directly to bypass this index and avoid a circular lookup.
+            var matchingResourceIds = await resourceProfileService.GetMatchingResourceIds(profile.Search);
+            matchingResourceIds.IntersectWith(resourceIds);
+            affectedMatchesByProfile[profile.Id] = matchingResourceIds;
+
+            foreach (var resourceId in matchingResourceIds)
+            {
+                matchingProfileIdsByResource[resourceId].Add(profile.Id);
+            }
+
+            processedProfiles++;
+            await ReportIncrementalProgress(
+                args,
+                ScaleProgress(progressStart, matchingProgressEnd, processedProfiles, allProfiles.Count),
+                "ResourceProfileIndex_MatchingProfilesForResources",
+                processedProfiles,
+                allProfiles.Count,
+                resourceIds.Count);
+        }
+
         foreach (var resourceId in resourceIds)
         {
-            args.CancellationToken.ThrowIfCancellationRequested();
-
-            // Clear existing mappings for this resource
-            var oldProfileIds = _resourceToProfiles.TryRemove(resourceId, out var removed)
-                ? removed
-                : Array.Empty<int>();
-            foreach (var profileId in oldProfileIds)
+            var oldProfileIds = oldProfileIdsByResource[resourceId];
+            var matchingProfileIds = matchingProfileIdsByResource[resourceId];
+            if (oldProfileIds.Count != matchingProfileIds.Count ||
+                !oldProfileIds.ToHashSet().SetEquals(matchingProfileIds))
             {
-                RemoveResourceFromProfile(profileId, resourceId);
+                matchingChangedResourceIds.Add(resourceId);
             }
+        }
 
-            // Re-evaluate against all profiles
-            var matchingProfileIds = new List<int>();
-            foreach (var profile in allProfiles)
+        // Persist cache invalidation while the old mappings are still intact. A failure leaves
+        // this snapshot fully retryable; after success the remaining mapping update is in-memory
+        // and contains no cancellation points that could expose a partially applied batch.
+        if (matchingChangedResourceIds.Count > 0)
+        {
+            await ReportIncrementalProgress(
+                args,
+                Math.Max(progressStart, progressEnd - 5),
+                "ResourceProfileIndex_InvalidatingPlayableFileCaches",
+                matchingChangedResourceIds.Count);
+            await resourceService.DeleteResourceCacheByResourceIdsAndCacheType(
+                matchingChangedResourceIds, ResourceCacheType.PlayableFiles);
+        }
+
+        await args.YieldAsync();
+        await ReportIncrementalProgress(
+            args,
+            progressEnd,
+            "ResourceProfileIndex_UpdatingResourceMappings",
+            resourceIds.Count);
+
+        // Update the profile -> resources side in one copy-on-write operation per profile. Only
+        // this invalidation batch is replaced; unrelated resources retain their prior membership
+        // even if another change is queued while these searches are running.
+        foreach (var profile in allProfiles)
+        {
+            var newMatches = affectedMatchesByProfile[profile.Id];
+            _profileToResources.AddOrUpdate(
+                profile.Id,
+                _ => new HashSet<int>(newMatches),
+                (_, existing) =>
+                {
+                    var updated = existing.ToHashSet();
+                    updated.ExceptWith(resourceIds);
+                    updated.UnionWith(newMatches);
+                    return updated;
+                });
+        }
+
+        // Preserve the old implementation's cleanup for cached profiles that are no longer
+        // returned by the profile service. Their dedicated profile invalidation will remove the
+        // rest of the stale mapping; this batch must still detach the resources in its snapshot.
+        foreach (var staleProfileId in oldProfileIdsByResource.Values
+                     .SelectMany(ids => ids)
+                     .Where(id => !activeProfileIds.Contains(id))
+                     .Distinct())
+        {
+            _profileToResources.AddOrUpdate(
+                staleProfileId,
+                _ => new HashSet<int>(),
+                (_, existing) =>
+                {
+                    var updated = existing.ToHashSet();
+                    updated.ExceptWith(resourceIds);
+                    return updated;
+                });
+
+            if (_profileToResources.TryGetValue(staleProfileId, out var remaining) && remaining.Count == 0)
             {
-                if (_profileToResources.TryGetValue(profile.Id, out var profileResourceIds))
-                {
-                    // Check if we need to re-evaluate - use profile.Search to bypass index cache
-                    var newMatchingIds = await resourceProfileService.GetMatchingResourceIds(profile.Search);
-                    if (newMatchingIds.Contains(resourceId))
-                    {
-                        matchingProfileIds.Add(profile.Id);
-                        AddResourceToProfile(profile.Id, resourceId);
-                    }
-                }
-                else
-                {
-                    // Profile has no cached resources, evaluate - use profile.Search to bypass index cache
-                    var matchingIds = await resourceProfileService.GetMatchingResourceIds(profile.Search);
-                    _profileToResources[profile.Id] = matchingIds;
-                    if (matchingIds.Contains(resourceId))
-                    {
-                        matchingProfileIds.Add(profile.Id);
-                    }
-                }
+                _profileToResources.TryRemove(staleProfileId, out _);
             }
+        }
+
+        foreach (var resourceId in resourceIds)
+        {
+            var matchingProfileIds = matchingProfileIdsByResource[resourceId];
 
             if (matchingProfileIds.Count > 0)
             {
@@ -491,20 +769,30 @@ public class ResourceProfileIndexService : IResourceProfileIndexService
                         .CompareTo(_profilePriorities.GetValueOrDefault(a, 0)));
                 _resourceToProfiles[resourceId] = matchingProfileIds;
             }
-
-            // Order-independent comparison of old vs new matching set.
-            if (!oldProfileIds.OrderBy(x => x).SequenceEqual(matchingProfileIds.OrderBy(x => x)))
+            else
             {
-                matchingChangedResourceIds.Add(resourceId);
+                _resourceToProfiles.TryRemove(resourceId, out _);
             }
         }
-
-        if (matchingChangedResourceIds.Count > 0)
-        {
-            await resourceService.DeleteResourceCacheByResourceIdsAndCacheType(
-                matchingChangedResourceIds, ResourceCacheType.PlayableFiles);
-        }
     }
+
+    private async Task ReportIncrementalProgress(
+        BTaskArgs args,
+        int percentage,
+        string processKey,
+        params object?[] processArguments)
+    {
+        await args.UpdateTask(t =>
+        {
+            t.Percentage = Math.Max(t.Percentage, percentage);
+            t.Process = processArguments.Length == 0
+                ? _localizer[processKey]
+                : _localizer[processKey, processArguments];
+        });
+    }
+
+    private static int ScaleProgress(int start, int end, int completed, int total) =>
+        total <= 0 ? end : start + (int)((long)(end - start) * completed / total);
 
     private void AddProfileToResource(int resourceId, int profileId)
     {

--- a/src/legacy/Bakabase.InsideWorld.Business/Services/ResourceSourceLinkService.cs
+++ b/src/legacy/Bakabase.InsideWorld.Business/Services/ResourceSourceLinkService.cs
@@ -34,7 +34,10 @@ public class ResourceSourceLinkService<TDbContext>(
 
     public async Task<List<ResourceSourceLink>> GetByResourceIds(int[] resourceIds)
     {
-        var dbModels = await orm.GetAll(m => resourceIds.Contains(m.ResourceId));
+        // The backing ORM evaluates this predicate against its full in-memory cache.
+        // Keep membership O(1) when a large incremental index batch is being rebuilt.
+        var resourceIdSet = resourceIds.ToHashSet();
+        var dbModels = await orm.GetAll(m => resourceIdSet.Contains(m.ResourceId));
         return dbModels.Select(d => d.ToDomainModel()).ToList();
     }
 

--- a/src/tests/Bakabase.TestKit/Implementations/TestBakabaseLocalizer.cs
+++ b/src/tests/Bakabase.TestKit/Implementations/TestBakabaseLocalizer.cs
@@ -111,9 +111,17 @@ public class TestBakabaseLocalizer : IBakabaseLocalizer
     // PathMark Sync
     public string SyncPathMark_Collecting() => "SyncPathMark_Collecting";
     public string SyncPathMark_Collected(int count) => $"SyncPathMark_Collected_{count}";
+    public string SyncPathMark_CollectingPropertyEffects() => "SyncPathMark_CollectingPropertyEffects";
     public string SyncPathMark_ProcessingResource(string path) => $"SyncPathMark_ProcessingResource_{path}";
     public string SyncPathMark_ProcessingProperty(string path) => $"SyncPathMark_ProcessingProperty_{path}";
+    public string SyncPathMark_CollectingMediaLibraryEffects() => "SyncPathMark_CollectingMediaLibraryEffects";
     public string SyncPathMark_ProcessingMediaLibrary(string path) => $"SyncPathMark_ProcessingMediaLibrary_{path}";
+    public string SyncPathMark_ComputingFinalState() => "SyncPathMark_ComputingFinalState";
+    public string SyncPathMark_ApplyingPropertyChanges() => "SyncPathMark_ApplyingPropertyChanges";
+    public string SyncPathMark_ApplyingMediaLibraryChanges() => "SyncPathMark_ApplyingMediaLibraryChanges";
+    public string SyncPathMark_PersistingEffects() => "SyncPathMark_PersistingEffects";
+    public string SyncPathMark_UpdatingSearchIndex() => "SyncPathMark_UpdatingSearchIndex";
+    public string SyncPathMark_UpdatingMarkStatuses() => "SyncPathMark_UpdatingMarkStatuses";
     public string SyncPathMark_FindingRelated() => "SyncPathMark_FindingRelated";
     public string SyncPathMark_FoundRelated(int count) => $"SyncPathMark_FoundRelated_{count}";
     public string SyncPathMark_EstablishingRelationships() => "SyncPathMark_EstablishingRelationships";

--- a/src/tests/Bakabase.Tests/PathMarkSyncProgressTests.cs
+++ b/src/tests/Bakabase.Tests/PathMarkSyncProgressTests.cs
@@ -1,0 +1,127 @@
+using Bakabase.Abstractions.Models.Domain;
+using Bakabase.Abstractions.Models.Domain.Constants;
+using Bakabase.Abstractions.Services;
+using Bakabase.InsideWorld.Business.Services;
+using Bakabase.TestKit.Utils;
+using Bootstrap.Components.Tasks;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Bakabase.Tests;
+
+[TestClass]
+public class PathMarkSyncProgressTests
+{
+    [TestMethod]
+    public async Task SyncMarks_ReportsLocalizedIndexBarrierBeforeCleanup()
+    {
+        var searchIndex = new BlockingResourceSearchIndexService();
+        var sp = await TestServiceBuilder.BuildServiceProvider(services =>
+        {
+            services.RemoveAll<IResourceSearchIndexService>();
+            services.AddSingleton<IResourceSearchIndexService>(searchIndex);
+        });
+
+        await sp.GetRequiredService<IPathMarkService>().Add(new PathMark
+        {
+            Path = Path.GetTempPath(),
+            Type = PathMarkType.Property,
+            ConfigJson =
+                "{\"matchMode\":1,\"layer\":0,\"pool\":4,\"propertyId\":999999,\"valueType\":1," +
+                "\"fixedValue\":\"unused\",\"applyScope\":1}",
+        });
+
+        var progress = new List<int>();
+        var processes = new List<string?>();
+        var syncTask = sp.GetRequiredService<PathMarkSyncService>().SyncMarks(
+            percentage =>
+            {
+                progress.Add(percentage);
+                return Task.CompletedTask;
+            },
+            process =>
+            {
+                processes.Add(process);
+                return Task.CompletedTask;
+            },
+            new PauseToken(),
+            CancellationToken.None);
+
+        try
+        {
+            await searchIndex.BarrierEntered.Task.WaitAsync(TimeSpan.FromSeconds(10));
+
+            progress.Should().EndWith(90);
+            progress.Should().OnlyContain(p => p < 95);
+            processes.Should().EndWith("SyncPathMark_UpdatingSearchIndex");
+        }
+        finally
+        {
+            searchIndex.ReleaseBarrier.TrySetResult();
+        }
+
+        await syncTask.WaitAsync(TimeSpan.FromSeconds(10));
+
+        progress.Should().BeInAscendingOrder();
+        progress.Should().ContainInOrder(80, 90, 95, 100);
+        processes.Should().ContainInOrder(
+            "SyncPathMark_CollectingPropertyEffects",
+            "SyncPathMark_CollectingMediaLibraryEffects",
+            "SyncPathMark_ComputingFinalState",
+            "SyncPathMark_ApplyingPropertyChanges",
+            "SyncPathMark_ApplyingMediaLibraryChanges",
+            "SyncPathMark_PersistingEffects",
+            "SyncPathMark_UpdatingSearchIndex",
+            "SyncPathMark_UpdatingMarkStatuses",
+            "SyncPathMark_Complete");
+    }
+
+    private sealed class BlockingResourceSearchIndexService : IResourceSearchIndexService
+    {
+        public TaskCompletionSource BarrierEntered { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        public TaskCompletionSource ReleaseBarrier { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public bool IsReady => true;
+        public long Version => 0;
+        public DateTime LastUpdatedAt => DateTime.MinValue;
+
+        public Task<HashSet<int>?> SearchResourceIdsAsync(ResourceSearchFilterGroup? group) =>
+            Task.FromResult<HashSet<int>?>(null);
+
+        public Task<Dictionary<string, int>?> GetPropertyValueResourceCountsAsync(PropertyPool pool, int propertyId,
+            IEnumerable<string> valueIds, IReadOnlySet<int>? resourceIds = null) =>
+            Task.FromResult<Dictionary<string, int>?>(null);
+
+        public void InvalidateResource(int resourceId)
+        {
+        }
+
+        public void InvalidateResources(IEnumerable<int> resourceIds)
+        {
+        }
+
+        public void RemoveResource(int resourceId)
+        {
+        }
+
+        public void RemoveResources(IEnumerable<int> resourceIds)
+        {
+        }
+
+        public async Task WaitForPendingUpdatesAsync(CancellationToken ct = default)
+        {
+            BarrierEntered.TrySetResult();
+            await ReleaseBarrier.Task.WaitAsync(ct);
+        }
+
+        public Task RebuildAllAsync(CancellationToken ct = default) => Task.CompletedTask;
+        public Task WaitForReadyAsync(TimeSpan? timeout = null) => Task.CompletedTask;
+
+        public ResourceSearchIndexStatus GetStatus() => new()
+        {
+            IsReady = true,
+        };
+    }
+}

--- a/src/tests/Bakabase.Tests/ResourceProfileIndexTests.cs
+++ b/src/tests/Bakabase.Tests/ResourceProfileIndexTests.cs
@@ -1,18 +1,27 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
+using Bakabase.Abstractions.Components.Events;
+using Bakabase.Abstractions.Components.Tasks;
+using Bakabase.Abstractions.Models.Db;
 using Bakabase.Abstractions.Models.Domain;
 using Bakabase.Abstractions.Models.Domain.Constants;
 using Bakabase.Abstractions.Services;
+using Bakabase.InsideWorld.Business;
+using Bakabase.InsideWorld.Business.Components.Search.Index;
+using Bakabase.InsideWorld.Business.Models.Db;
 using Bakabase.InsideWorld.Business.Services;
 using Bakabase.InsideWorld.Models.Constants.Aos;
 using Bakabase.Modules.Search.Models.Db;
 using Bakabase.TestKit.Utils;
 using Bootstrap.Components.Tasks;
+using Bootstrap.Components.Orm;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Newtonsoft.Json;
 
 namespace Bakabase.Tests;
@@ -26,13 +35,22 @@ namespace Bakabase.Tests;
 [TestClass]
 public sealed class ResourceProfileIndexTests
 {
+    private const string ResourceProfileIndexTaskId = "ResourceProfileIndex";
     private string _testRoot = null!;
     private IServiceProvider _sp = null!;
+    private ControllableResourceSearchIndexService _searchIndex = null!;
 
     [TestInitialize]
     public async Task Setup()
     {
-        _sp = await TestServiceBuilder.BuildServiceProvider();
+        _sp = await TestServiceBuilder.BuildServiceProvider(services =>
+        {
+            services.RemoveAll<IResourceSearchIndexService>();
+            services.AddSingleton<ControllableResourceSearchIndexService>();
+            services.AddSingleton<IResourceSearchIndexService>(sp =>
+                sp.GetRequiredService<ControllableResourceSearchIndexService>());
+        });
+        _searchIndex = _sp.GetRequiredService<ControllableResourceSearchIndexService>();
         _testRoot = Path.Combine(
             Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)!,
             $"ResourceProfileIndexTests.{DateTime.Now:yyyyMMddHHmmssfff}.{Guid.NewGuid():N}");
@@ -101,6 +119,46 @@ public sealed class ResourceProfileIndexTests
 
     private async Task<int> ResourceId(string filename)
         => (await _sp.GetRequiredService<IResourceService>().GetAll()).Single(r => r.FileName == filename).Id;
+
+    private async Task RunPendingIncrementalUpdate()
+    {
+        var taskManager = _sp.GetRequiredService<BTaskManager>();
+        var enqueueDeadline = DateTime.UtcNow + TimeSpan.FromSeconds(10);
+        while (DateTime.UtcNow < enqueueDeadline)
+        {
+            var queuedTask = taskManager.GetTaskViewModel(ResourceProfileIndexTaskId);
+            if (queuedTask != null && !queuedTask.Status.IsFinished()) break;
+            await Task.Delay(20);
+        }
+
+        var task = taskManager.GetTaskViewModel(ResourceProfileIndexTaskId);
+        Assert.IsNotNull(task,
+            "Resource profile index update task was not enqueued after invalidation");
+        Assert.IsFalse(task!.Status.IsFinished(),
+            "Resource profile index update task was not replaced after the previous run finished");
+
+        await taskManager.Start(ResourceProfileIndexTaskId);
+        var completionDeadline = DateTime.UtcNow + TimeSpan.FromSeconds(10);
+        while (DateTime.UtcNow < completionDeadline)
+        {
+            var status = taskManager.GetTaskViewModel(ResourceProfileIndexTaskId)?.Status;
+            if (status == BTaskStatus.Completed) return;
+            if (status == BTaskStatus.Error)
+            {
+                Assert.Fail("Resource profile index update task failed");
+            }
+
+            await Task.Delay(20);
+        }
+
+        Assert.Fail("Resource profile index update task did not complete within the timeout");
+    }
+
+    private async Task DrainSetupInvalidations()
+    {
+        await RunPendingIncrementalUpdate();
+        await _sp.GetRequiredService<BTaskManager>().Clean(ResourceProfileIndexTaskId);
+    }
 
     [TestMethod]
     public async Task RebuildAsync_MakesIndexReady()
@@ -199,5 +257,276 @@ public sealed class ResourceProfileIndexTests
         await Seed("a");
         await RebuildIndex();
         Assert.AreEqual(0, (await Index().GetMatchingProfileIds(await ResourceId("a"))).Count);
+    }
+
+    [TestMethod]
+    public async Task ProfileInvalidation_ReplacesMappings_ReordersPriorityAndInvalidatesCaches()
+    {
+        await Seed("apple", "banana");
+        var movedProfile = await AddProfile("moving", FilenameEqualsSearchJson("apple"), priority: 10);
+        var catchAllProfile = await AddProfile("all", "{}", priority: 20);
+        await _searchIndex.RebuildAllAsync(CancellationToken.None);
+        await RebuildIndex();
+        await DrainSetupInvalidations();
+
+        var appleResourceId = await ResourceId("apple");
+        var bananaResourceId = await ResourceId("banana");
+        var cacheOrm = _sp.GetRequiredService<
+            FullMemoryCacheResourceService<BakabaseDbContext, ResourceCacheDbModel, int>>();
+        await cacheOrm.AddRange(
+        [
+            new ResourceCacheDbModel
+            {
+                ResourceId = appleResourceId,
+                CachedTypes = ResourceCacheType.PlayableFiles,
+                PlayableFilePaths = JsonConvert.SerializeObject(new[] { "apple.mp4" })
+            },
+            new ResourceCacheDbModel
+            {
+                ResourceId = bananaResourceId,
+                CachedTypes = ResourceCacheType.PlayableFiles,
+                PlayableFilePaths = JsonConvert.SerializeObject(new[] { "banana.mp4" })
+            }
+        ]);
+
+        await _sp.GetRequiredService<IResourceProfileService>().Update(
+            movedProfile.Id,
+            "moving",
+            FilenameEqualsSearchJson("banana"),
+            null,
+            null,
+            null,
+            null,
+            null,
+            30);
+        await RunPendingIncrementalUpdate();
+
+        CollectionAssert.AreEqual(
+            new[] { catchAllProfile.Id },
+            (await Index().GetMatchingProfileIds(appleResourceId)).ToList());
+        CollectionAssert.AreEqual(
+            new[] { movedProfile.Id, catchAllProfile.Id },
+            (await Index().GetMatchingProfileIds(bananaResourceId)).ToList(),
+            "a priority edit must re-sort an existing reverse mapping");
+        Assert.IsFalse((await Index().GetMatchingResourceIds(movedProfile.Id)).Contains(appleResourceId));
+        Assert.IsTrue((await Index().GetMatchingResourceIds(movedProfile.Id)).Contains(bananaResourceId));
+
+        foreach (var resourceId in new[] { appleResourceId, bananaResourceId })
+        {
+            var cache = await cacheOrm.GetByKey(resourceId);
+            Assert.IsNotNull(cache);
+            Assert.IsFalse(cache!.CachedTypes.HasFlag(ResourceCacheType.PlayableFiles));
+            Assert.IsNull(cache.PlayableFilePaths);
+        }
+    }
+
+    [TestMethod]
+    public async Task ResourceInvalidation_BulkUpdatesBothMappings_PreservesOrderAndInvalidatesChangedCache()
+    {
+        await Seed("apple", "banana");
+        var appleProfile = await AddProfile("apple", FilenameEqualsSearchJson("apple"), priority: 20);
+        var cherryProfile = await AddProfile("cherry", FilenameEqualsSearchJson("cherry"), priority: 30);
+        var catchAllProfile = await AddProfile("all", "{}", priority: 10);
+        await _sp.GetRequiredService<IResourceSearchIndexService>().RebuildAllAsync(CancellationToken.None);
+        await RebuildIndex();
+        await DrainSetupInvalidations();
+
+        var appleResourceId = await ResourceId("apple");
+        var bananaResourceId = await ResourceId("banana");
+        var cacheOrm = _sp.GetRequiredService<
+            FullMemoryCacheResourceService<BakabaseDbContext, ResourceCacheDbModel, int>>();
+        await cacheOrm.AddRange(
+        [
+            new ResourceCacheDbModel
+            {
+                ResourceId = appleResourceId,
+                CachedTypes = ResourceCacheType.PlayableFiles,
+                PlayableFilePaths = JsonConvert.SerializeObject(new[] { "apple.mp4" })
+            },
+            new ResourceCacheDbModel
+            {
+                ResourceId = bananaResourceId,
+                CachedTypes = ResourceCacheType.PlayableFiles,
+                PlayableFilePaths = JsonConvert.SerializeObject(new[] { "banana.mp4" })
+            }
+        ]);
+
+        // Publish the same event production writes use: the search-index update and profile-index
+        // invalidation are asynchronous siblings, so the profile task must wait for the former.
+        var resourceOrm = _sp.GetRequiredService<
+            FullMemoryCacheResourceService<BakabaseDbContext, ResourceDbModel, int>>();
+        await resourceOrm.UpdateByKey(
+            appleResourceId,
+            r => r.Path = Path.Combine(_testRoot, "cherry"));
+
+        _sp.GetRequiredService<IResourceDataChangeEventPublisher>()
+            .PublishResourcesChanged([appleResourceId, bananaResourceId]);
+        await RunPendingIncrementalUpdate();
+
+        CollectionAssert.AreEqual(
+            new[] { cherryProfile.Id, catchAllProfile.Id },
+            (await Index().GetMatchingProfileIds(appleResourceId)).ToList(),
+            "Forward mappings should reflect the renamed resource and remain priority ordered");
+        CollectionAssert.AreEqual(
+            new[] { catchAllProfile.Id },
+            (await Index().GetMatchingProfileIds(bananaResourceId)).ToList(),
+            "An invalidated resource whose matching set did not change should retain its mapping");
+
+        Assert.IsFalse((await Index().GetMatchingResourceIds(appleProfile.Id)).Contains(appleResourceId));
+        Assert.IsTrue((await Index().GetMatchingResourceIds(cherryProfile.Id)).Contains(appleResourceId));
+        Assert.IsTrue((await Index().GetMatchingResourceIds(catchAllProfile.Id)).Contains(appleResourceId));
+
+        var appleCache = await cacheOrm.GetByKey(appleResourceId);
+        var bananaCache = await cacheOrm.GetByKey(bananaResourceId);
+        Assert.IsNotNull(appleCache);
+        Assert.IsNotNull(bananaCache);
+        Assert.IsFalse(appleCache!.CachedTypes.HasFlag(ResourceCacheType.PlayableFiles));
+        Assert.IsNull(appleCache.PlayableFilePaths);
+        Assert.IsTrue(bananaCache!.CachedTypes.HasFlag(ResourceCacheType.PlayableFiles));
+        Assert.IsNotNull(bananaCache.PlayableFilePaths);
+
+        var taskManager = _sp.GetRequiredService<BTaskManager>();
+        var percentages = taskManager.GetPercentageEvents(ResourceProfileIndexTaskId)
+            .Select(e => e.Event)
+            .ToList();
+        Assert.IsTrue(percentages.Any(p => p is > 0 and < 100),
+            "Incremental work should report non-zero progress before completion");
+        Assert.AreEqual(1, percentages.First(),
+            "Incremental work should leave 0% as soon as processing starts");
+        Assert.IsTrue(percentages.Zip(percentages.Skip(1), (left, right) => right >= left).All(x => x),
+            "Incremental progress should be monotonic");
+        var processes = taskManager.GetProcessEvents(ResourceProfileIndexTaskId)
+            .Select(e => e.Event)
+            .ToList();
+        Assert.IsTrue(processes.Any(p => !string.IsNullOrWhiteSpace(p)),
+            "Incremental work should report its process");
+        Assert.AreEqual("ResourceProfileIndex_LoadingIncrementalUpdates", processes.First(),
+            "Incremental work should report its process from the beginning");
+    }
+
+    [TestMethod]
+    public async Task ResourceInvalidation_ArrivingDuringActiveTask_IsProcessedByFollowUpTask()
+    {
+        await Seed("apple", "banana");
+        var appleProfile = await AddProfile("apple", FilenameEqualsSearchJson("apple"));
+        var bananaProfile = await AddProfile("banana", FilenameEqualsSearchJson("banana"));
+        var cherryProfile = await AddProfile("cherry", FilenameEqualsSearchJson("cherry"));
+        var dateProfile = await AddProfile("date", FilenameEqualsSearchJson("date"));
+        await _searchIndex.RebuildAllAsync(CancellationToken.None);
+        await RebuildIndex();
+        await DrainSetupInvalidations();
+
+        var appleResourceId = await ResourceId("apple");
+        var bananaResourceId = await ResourceId("banana");
+        var resourceOrm = _sp.GetRequiredService<
+            FullMemoryCacheResourceService<BakabaseDbContext, ResourceDbModel, int>>();
+        var publisher = _sp.GetRequiredService<IResourceDataChangeEventPublisher>();
+
+        await resourceOrm.UpdateByKey(
+            appleResourceId,
+            r => r.Path = Path.Combine(_testRoot, "cherry"));
+        var barrier = _searchIndex.BlockNextBarrier();
+        publisher.PublishResourcesChanged([appleResourceId]);
+
+        var firstUpdate = RunPendingIncrementalUpdate();
+        await barrier.Entered.WaitAsync(TimeSpan.FromSeconds(10));
+
+        // The first task has drained its queue snapshot and is now waiting for SearchIndex.
+        // This later change must remain queued and cause a second ResourceProfileIndex task.
+        await resourceOrm.UpdateByKey(
+            bananaResourceId,
+            r => r.Path = Path.Combine(_testRoot, "date"));
+        publisher.PublishResourcesChanged([bananaResourceId]);
+
+        Assert.IsFalse(firstUpdate.IsCompleted,
+            "The profile task must not evaluate mappings before the search-index barrier completes");
+        barrier.Release();
+        await firstUpdate;
+
+        CollectionAssert.Contains(
+            (await Index().GetMatchingProfileIds(appleResourceId)).ToList(),
+            cherryProfile.Id);
+        CollectionAssert.DoesNotContain(
+            (await Index().GetMatchingProfileIds(appleResourceId)).ToList(),
+            appleProfile.Id);
+        CollectionAssert.Contains(
+            (await Index().GetMatchingProfileIds(bananaResourceId)).ToList(),
+            bananaProfile.Id,
+            "The first snapshot must not silently consume an invalidation that arrived later");
+
+        await RunPendingIncrementalUpdate();
+
+        CollectionAssert.Contains(
+            (await Index().GetMatchingProfileIds(bananaResourceId)).ToList(),
+            dateProfile.Id);
+        CollectionAssert.DoesNotContain(
+            (await Index().GetMatchingProfileIds(bananaResourceId)).ToList(),
+            bananaProfile.Id);
+    }
+
+    private sealed class ControllableResourceSearchIndexService(ResourceSearchIndexService inner)
+        : IResourceSearchIndexService
+    {
+        private BarrierGate? _nextBarrier;
+
+        public bool IsReady => inner.IsReady;
+        public long Version => inner.Version;
+        public DateTime LastUpdatedAt => inner.LastUpdatedAt;
+
+        public BarrierGate BlockNextBarrier()
+        {
+            var gate = new BarrierGate();
+            if (Interlocked.CompareExchange(ref _nextBarrier, gate, null) != null)
+            {
+                throw new InvalidOperationException("A search-index barrier is already blocked");
+            }
+
+            return gate;
+        }
+
+        public Task<HashSet<int>?> SearchResourceIdsAsync(ResourceSearchFilterGroup? group) =>
+            inner.SearchResourceIdsAsync(group);
+
+        public Task<Dictionary<string, int>?> GetPropertyValueResourceCountsAsync(
+            PropertyPool pool,
+            int propertyId,
+            IEnumerable<string> valueIds,
+            IReadOnlySet<int>? resourceIds = null) =>
+            inner.GetPropertyValueResourceCountsAsync(pool, propertyId, valueIds, resourceIds);
+
+        public void InvalidateResource(int resourceId) => inner.InvalidateResource(resourceId);
+        public void InvalidateResources(IEnumerable<int> resourceIds) => inner.InvalidateResources(resourceIds);
+        public void RemoveResource(int resourceId) => inner.RemoveResource(resourceId);
+        public void RemoveResources(IEnumerable<int> resourceIds) => inner.RemoveResources(resourceIds);
+
+        public async Task WaitForPendingUpdatesAsync(CancellationToken ct = default)
+        {
+            var gate = Interlocked.Exchange(ref _nextBarrier, null);
+            if (gate != null)
+            {
+                gate.MarkEntered();
+                await gate.WaitForRelease(ct);
+            }
+
+            await inner.WaitForPendingUpdatesAsync(ct);
+        }
+
+        public Task RebuildAllAsync(CancellationToken ct = default) => inner.RebuildAllAsync(ct);
+        public Task WaitForReadyAsync(TimeSpan? timeout = null) => inner.WaitForReadyAsync(timeout);
+        public ResourceSearchIndexStatus GetStatus() => inner.GetStatus();
+
+        public sealed class BarrierGate
+        {
+            private readonly TaskCompletionSource _entered =
+                new(TaskCreationOptions.RunContinuationsAsynchronously);
+            private readonly TaskCompletionSource _release =
+                new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            public Task Entered => _entered.Task;
+
+            public void MarkEntered() => _entered.TrySetResult();
+            public void Release() => _release.TrySetResult();
+            public Task WaitForRelease(CancellationToken ct) => _release.Task.WaitAsync(ct);
+        }
     }
 }

--- a/src/tests/Bakabase.Tests/ResourceSearchIndexIncrementalTests.cs
+++ b/src/tests/Bakabase.Tests/ResourceSearchIndexIncrementalTests.cs
@@ -121,6 +121,27 @@ public sealed class ResourceSearchIndexIncrementalTests
         return resp.Data!.Count;
     }
 
+    private async Task<HashSet<int>?> SearchIdsByFilename(
+        IResourceSearchIndexService index,
+        string value)
+    {
+        return await index.SearchResourceIdsAsync(new ResourceSearchFilterGroup
+        {
+            Combinator = SearchCombinator.And,
+            Filters =
+            [
+                new ResourceSearchFilter
+                {
+                    PropertyPool = PropertyPool.Internal,
+                    PropertyId = (int)InternalProperty.Filename,
+                    Operation = SearchOperation.Equals,
+                    DbValue = value,
+                    Property = _filenameProperty
+                }
+            ]
+        });
+    }
+
     [TestMethod]
     public async Task RemoveResource_RemovesFromIndex()
     {
@@ -174,11 +195,11 @@ public sealed class ResourceSearchIndexIncrementalTests
         await BuildIndex();
         var id = await ResourceId("a");
 
-        Index().RemoveResource(id);
+        Index().RemoveResources([id, id]);
         await WaitForPendingUpdatesAndAssertCount(1);
 
         // The resource still exists in the database; invalidation must re-read and re-index it.
-        Index().InvalidateResource(id);
+        Index().InvalidateResources([id, id]);
         await WaitForPendingUpdatesAndAssertCount(2);
     }
 
@@ -196,22 +217,120 @@ public sealed class ResourceSearchIndexIncrementalTests
     }
 
     [TestMethod]
-    public async Task WaitForPendingUpdates_WaitsAcrossBatchBoundary()
+    public async Task WaitForPendingUpdates_CoalescedUpdateAndRemove_RemoveWins()
     {
         await Seed("a", "b");
         await BuildIndex();
         var id = await ResourceId("a");
 
+        // Repeated and adjacent notifications for one resource collapse into one logical
+        // operation. Remove wins within the barrier-delimited segment so an update cannot
+        // resurrect an entry deleted by the same logical change.
         for (var i = 0; i < 100; i++)
         {
             Index().InvalidateResource(id);
         }
-        Index().RemoveResource(id);
+        Index().RemoveResources([id, id]);
 
-        // The remove is the 101st operation, so it must be processed in the batch after
-        // the first 100 invalidations before the FIFO barrier can complete.
         await WaitForPendingUpdatesAndAssertCount(1);
         Assert.AreEqual(0, await SearchCountByFilename("a"));
+
+        // A new segment after the barrier is allowed to re-read an extant database row.
+        Index().InvalidateResources([id, id]);
+        await WaitForPendingUpdatesAndAssertCount(2);
+        Assert.AreEqual(1, await SearchCountByFilename("a"));
+    }
+
+    [TestMethod]
+    public async Task BulkInvalidations_DeduplicateAcrossAdjacentQueueItems()
+    {
+        await Seed("a", "b");
+        var scopeFactory = new CountingScopeFactory(_sp.GetRequiredService<IServiceScopeFactory>());
+        var index = new ResourceSearchIndexService(
+            scopeFactory,
+            _sp.GetRequiredService<IResourceDataChangeEvent>(),
+            _sp.GetRequiredService<ILogger<ResourceSearchIndexService>>(),
+            _sp.GetRequiredService<IBakabaseLocalizer>());
+
+        await index.RebuildAllAsync(CancellationToken.None);
+        scopeFactory.Reset();
+        var versionBefore = index.Version;
+        var a = await ResourceId("a");
+        var b = await ResourceId("b");
+
+        // More than the former 100-operation batch size, spread across adjacent bulk
+        // notifications and containing duplicates both within and across calls.
+        for (var i = 0; i < 150; i++)
+        {
+            index.InvalidateResources([a, a, b]);
+            index.InvalidateResources([b, a]);
+        }
+        index.InvalidateResource(a);
+        await index.WaitForPendingUpdatesAsync(CancellationToken.None);
+
+        Assert.AreEqual(1, scopeFactory.ScopeCount,
+            "adjacent bulk and single notifications should share one data-loading pass");
+        Assert.AreEqual(versionBefore + 1, index.Version,
+            "one coalesced batch should advance the index version once");
+        CollectionAssert.AreEquivalent(new[] {a}, (await SearchIdsByFilename(index, "a"))!.ToArray());
+        CollectionAssert.AreEquivalent(new[] {b}, (await SearchIdsByFilename(index, "b"))!.ToArray());
+    }
+
+    [TestMethod]
+    public async Task WaitForPendingUpdates_WaitsAcrossCoalescedBatchBoundary()
+    {
+        var scopeFactory = new CountingScopeFactory(_sp.GetRequiredService<IServiceScopeFactory>());
+        var index = new ResourceSearchIndexService(
+            scopeFactory,
+            _sp.GetRequiredService<IResourceDataChangeEvent>(),
+            _sp.GetRequiredService<ILogger<ResourceSearchIndexService>>(),
+            _sp.GetRequiredService<IBakabaseLocalizer>());
+
+        await index.RebuildAllAsync(CancellationToken.None);
+        scopeFactory.Reset();
+        var versionBefore = index.Version;
+
+        // Two adjacent notifications exceed the 4096-distinct-resource processing bound.
+        // The second item is therefore split by the reader, and the FIFO barrier must wait
+        // for both resulting batches rather than acknowledging only the first prefix.
+        index.InvalidateResources(Enumerable.Range(10_000, 3_000));
+        index.InvalidateResources(Enumerable.Range(13_000, 3_000));
+
+        await index.WaitForPendingUpdatesAsync(CancellationToken.None);
+
+        Assert.AreEqual(2, scopeFactory.ScopeCount,
+            "the bounded update should require exactly two data-loading passes");
+        Assert.AreEqual(versionBefore + 2, index.Version,
+            "both bounded batches must be committed before the barrier completes");
+        Assert.AreEqual(0, index.GetStatus().PendingUpdateCount);
+    }
+
+    [TestMethod]
+    public async Task Barrier_DoesNotIncludeFailureFromFollowingBatch()
+    {
+        await Seed("a");
+        var scopeFactory = new FailNextScopeFactory(_sp.GetRequiredService<IServiceScopeFactory>());
+        var index = new ResourceSearchIndexService(
+            scopeFactory,
+            _sp.GetRequiredService<IResourceDataChangeEvent>(),
+            _sp.GetRequiredService<ILogger<ResourceSearchIndexService>>(),
+            _sp.GetRequiredService<IBakabaseLocalizer>());
+
+        await index.RebuildAllAsync(CancellationToken.None);
+        var id = await ResourceId("a");
+
+        index.RemoveResource(id);
+        var firstBarrier = index.WaitForPendingUpdatesAsync(CancellationToken.None);
+
+        // This permanently failing update is queued after the first barrier. It must not
+        // be merged into the preceding removal or retroactively fault that barrier.
+        scopeFactory.FailNext(3);
+        index.InvalidateResource(id);
+
+        await firstBarrier;
+        await Assert.ThrowsExceptionAsync<InvalidOperationException>(
+            () => index.WaitForPendingUpdatesAsync(CancellationToken.None));
+        Assert.IsFalse(index.IsReady);
     }
 
     [TestMethod]
@@ -272,6 +391,21 @@ public sealed class ResourceSearchIndexIncrementalTests
         CollectionAssert.AreEqual(
             new[] {await ResourceId("a")},
             (await index.SearchResourceIdsAsync(filter))!.OrderBy(x => x).ToArray());
+    }
+
+    private sealed class CountingScopeFactory(IServiceScopeFactory inner) : IServiceScopeFactory
+    {
+        private int _scopeCount;
+
+        public int ScopeCount => Volatile.Read(ref _scopeCount);
+
+        public void Reset() => Volatile.Write(ref _scopeCount, 0);
+
+        public IServiceScope CreateScope()
+        {
+            Interlocked.Increment(ref _scopeCount);
+            return inner.CreateScope();
+        }
     }
 
     private sealed class FailNextScopeFactory(IServiceScopeFactory inner) : IServiceScopeFactory

--- a/src/web/src/locales/cn/pages/pathMarkConfig.json
+++ b/src/web/src/locales/cn/pages/pathMarkConfig.json
@@ -155,7 +155,7 @@
   "markDescription.empty": "无描述",
   "markDescription.invalid": "配置无效",
   "pathMarkConfig.tip.clickToEditRightClickDelete": "点击编辑，右键删除",
-  "pathMarkConfig.status.syncProgress": "同步中: {{progress}}%",
+  "pathMarkConfig.status.overallSyncProgress": "整体同步进度: {{progress}}%",
   "pathMarkConfig.tip.recheckAfter": "重新检查于",
   "pathMarkConfig.action.viewAllMarks": "查看全部标记",
   "pathMarkConfig.label.nextStepHint": "下一步：查看所有已配置的标记，或配置资源扩展来定义增强器、播放器等设置",

--- a/src/web/src/locales/en/pages/pathMarkConfig.json
+++ b/src/web/src/locales/en/pages/pathMarkConfig.json
@@ -155,7 +155,7 @@
   "markDescription.empty": "No description",
   "markDescription.invalid": "Invalid config",
   "pathMarkConfig.tip.clickToEditRightClickDelete": "Click to edit, right-click to delete",
-  "pathMarkConfig.status.syncProgress": "Syncing: {{progress}}%",
+  "pathMarkConfig.status.overallSyncProgress": "Overall sync progress: {{progress}}%",
   "pathMarkConfig.tip.recheckAfter": "Re-check after",
   "pathMarkConfig.action.viewAllMarks": "View All Marks",
   "pathMarkConfig.label.nextStepHint": "Next step: View all configured marks, or configure Resource Profiles to define enhancers, players, and other settings",

--- a/src/web/src/pages/path-mark-config/components/PathMarkChip.tsx
+++ b/src/web/src/pages/path-mark-config/components/PathMarkChip.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import type { BakabaseAbstractionsModelsDomainPathMark } from "@/sdk/Api";
-import type { BTask } from "@/core/models/BTask";
 
 import { useCallback, useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -15,6 +14,11 @@ import {
 import { AiOutlineFieldTime } from "react-icons/ai";
 
 import MarkDescription from "./MarkDescription";
+import {
+  getPathMarkSyncProgress,
+  getPathMarkSyncTask,
+  isPathMarkSyncTaskActive,
+} from "./pathMarkSyncTask";
 
 import {
   Chip,
@@ -25,7 +29,7 @@ import {
   Button,
   toast,
 } from "@/components/bakaui";
-import { PathMarkType, PathMarkSyncStatus, BTaskStatus } from "@/sdk/constants";
+import { PathMarkType, PathMarkSyncStatus } from "@/sdk/constants";
 import { useBTasksStore } from "@/stores/bTasks";
 import { usePathMarksStore } from "@/stores/pathMarks";
 import BApi from "@/sdk/BApi";
@@ -39,9 +43,6 @@ export interface PathMarkChipProps {
   onSelectionChange?: (selected: boolean) => void;
 }
 
-// Build task ID for a single mark sync
-const buildMarkTaskId = (markId: number) => `SyncPathMark_${markId}`;
-
 const getSyncStatusIcon = (status?: number, isTaskRunning?: boolean, taskProgress?: number) => {
   // If task is running, show CircularProgress
   if (isTaskRunning) {
@@ -51,8 +52,9 @@ const getSyncStatusIcon = (status?: number, isTaskRunning?: boolean, taskProgres
         classNames={{
           svg: "w-3.5 h-3.5",
         }}
+        isIndeterminate={taskProgress == null}
         size="sm"
-        value={taskProgress || 0}
+        value={taskProgress}
       />
     );
   }
@@ -140,7 +142,7 @@ const PathMarkChip = ({
   const { t } = useTranslation();
   const [syncing, setSyncing] = useState(false);
 
-  // Watch BTask store for this mark's sync task
+  // Path-mark synchronization is represented by one global BTask.
   const bTasks = useBTasksStore((state) => state.tasks);
 
   // Get the latest mark state from store (updated via SignalR)
@@ -155,17 +157,14 @@ const PathMarkChip = ({
   const label = getMarkTypeLabel(mark.type, t);
   const isPendingDelete = mark.syncStatus === PathMarkSyncStatus.PendingDelete;
 
-  // Check if there's an active task for this mark
-  const markTask = mark.id
-    ? (bTasks?.find((task) => task.id === buildMarkTaskId(mark.id!)) as BTask | undefined)
-    : undefined;
-  const isTaskRunning =
-    markTask?.status === BTaskStatus.Running || markTask?.status === BTaskStatus.NotStarted;
-  const taskProgress = markTask?.percentage || 0;
+  const pathMarkSyncTask = getPathMarkSyncTask(bTasks);
+  const isMarkSyncing = mark.syncStatus === PathMarkSyncStatus.Syncing;
+  const isTaskRunning = isMarkSyncing && isPathMarkSyncTaskActive(pathMarkSyncTask);
+  const taskProgress = getPathMarkSyncProgress(pathMarkSyncTask);
 
   // Sync this mark immediately
   const handleSyncMark = useCallback(async () => {
-    if (!mark.id || syncing || isTaskRunning) return;
+    if (!mark.id || syncing || isMarkSyncing) return;
 
     setSyncing(true);
     try {
@@ -176,7 +175,7 @@ const PathMarkChip = ({
     } finally {
       setSyncing(false);
     }
-  }, [mark.id, syncing, isTaskRunning, t]);
+  }, [mark.id, syncing, isMarkSyncing, t]);
 
   const chipContent = (
     <Chip
@@ -215,7 +214,7 @@ const PathMarkChip = ({
   }
 
   // Can sync if mark has an id and is not already syncing/running
-  const canSync = mark.id && !syncing && !isTaskRunning && !isPendingDelete;
+  const canSync = mark.id && !syncing && !isMarkSyncing && !isPendingDelete;
 
   return (
     <Tooltip
@@ -230,7 +229,11 @@ const PathMarkChip = ({
           )}
           {isTaskRunning && (
             <span className="text-xs opacity-80">
-              {t("pathMarkConfig.status.syncProgress", { progress: Math.round(taskProgress) })}
+              {taskProgress == null
+                ? t("pathMarkConfig.status.syncing")
+                : t("pathMarkConfig.status.overallSyncProgress", {
+                    progress: Math.round(taskProgress),
+                  })}
             </span>
           )}
           {mark.expiresInSeconds != null && mark.expiresInSeconds > 0 && (

--- a/src/web/src/pages/path-mark-config/components/PathMarks.tsx
+++ b/src/web/src/pages/path-mark-config/components/PathMarks.tsx
@@ -2,7 +2,6 @@
 
 import type { Entry } from "@/core/models/FileExplorer/Entry";
 import type { BakabaseAbstractionsModelsDomainPathMark } from "@/sdk/Api";
-import type { BTask } from "@/core/models/BTask";
 
 import React, { useCallback, useEffect, useRef } from "react";
 import { useTranslation } from "react-i18next";
@@ -11,9 +10,10 @@ import { AiOutlineCopy } from "react-icons/ai";
 import MarkConfigModal from "./MarkConfigModal";
 import PathMarkChip from "./PathMarkChip";
 import AddMarkDropdown from "./AddMarkDropdown";
+import { didPathMarkSyncTaskComplete, getPathMarkSyncTask } from "./pathMarkSyncTask";
 
 import { Button } from "@/components/bakaui";
-import { PathMarkType, BTaskStatus } from "@/sdk/constants";
+import { PathMarkType, type BTaskStatus } from "@/sdk/constants";
 import { useBakabaseContext } from "@/components/ContextProvider/BakabaseContextProvider";
 import { useBTasksStore } from "@/stores/bTasks";
 import { useCopyMarksStore } from "@/stores/copyMarks";
@@ -30,15 +30,13 @@ type Props = {
   onTaskComplete?: () => void;
 };
 
-// Build task ID for a single mark sync
-const buildMarkTaskId = (markId: number) => `SyncPathMark_${markId}`;
-
 const PathMarks = ({ entry, marks = [], onSaveMark, onDeleteMark, onTaskComplete }: Props) => {
   const { t } = useTranslation();
   const { createPortal } = useBakabaseContext();
 
-  // Watch BTask store for individual mark sync tasks
+  // Path-mark synchronization is represented by one global BTask.
   const bTasks = useBTasksStore((state) => state.tasks);
+  const pathMarkSyncTask = getPathMarkSyncTask(bTasks);
 
   // Copy marks store
   const {
@@ -54,46 +52,19 @@ const PathMarks = ({ entry, marks = [], onSaveMark, onDeleteMark, onTaskComplete
   const isInCopyMode = copyModeEntryPath === entry.path;
 
   // Track previous task statuses to detect completion
-  const prevTaskStatusesRef = useRef<Map<string, BTaskStatus>>(new Map());
+  const prevTaskStatusRef = useRef<BTaskStatus>();
 
   // Detect task completion and trigger refresh
   useEffect(() => {
-    if (!marks.length || !bTasks) return;
+    const previousStatus = prevTaskStatusRef.current;
+    const currentStatus = pathMarkSyncTask?.status;
 
-    const prevStatuses = prevTaskStatusesRef.current;
-    let hasCompletedTask = false;
-
-    for (const mark of marks) {
-      if (!mark.id) continue;
-      const taskId = buildMarkTaskId(mark.id);
-      const task = bTasks.find((t) => t.id === taskId) as BTask | undefined;
-      const prevStatus = prevStatuses.get(taskId);
-
-      if (task) {
-        // Check if task just completed (was running/not started, now completed)
-        if (
-          prevStatus !== undefined &&
-          (prevStatus === BTaskStatus.Running || prevStatus === BTaskStatus.NotStarted) &&
-          task.status === BTaskStatus.Completed
-        ) {
-          hasCompletedTask = true;
-        }
-
-        prevStatuses.set(taskId, task.status);
-      } else if (
-        prevStatus !== undefined &&
-        (prevStatus === BTaskStatus.Running || prevStatus === BTaskStatus.NotStarted)
-      ) {
-        // Task was running but is now removed from the list - treat as completed
-        hasCompletedTask = true;
-        prevStatuses.delete(taskId);
-      }
+    if (didPathMarkSyncTaskComplete(previousStatus, currentStatus)) {
+      onTaskComplete?.();
     }
 
-    if (hasCompletedTask && onTaskComplete) {
-      onTaskComplete();
-    }
-  }, [bTasks, marks, onTaskComplete]);
+    prevTaskStatusRef.current = currentStatus;
+  }, [pathMarkSyncTask?.status, onTaskComplete]);
 
   const resourceMarks = marks.filter((m) => m.type === PathMarkType.Resource);
   const propertyMarks = marks.filter((m) => m.type === PathMarkType.Property);

--- a/src/web/src/pages/path-mark-config/components/PendingSyncButton.tsx
+++ b/src/web/src/pages/path-mark-config/components/PendingSyncButton.tsx
@@ -1,14 +1,14 @@
-import type { BTask } from "@/core/models/BTask";
+import type { BTaskStatus } from "@/sdk/constants";
 
 import { useState, useEffect, useCallback, useImperativeHandle, forwardRef, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import { AiOutlineSync } from "react-icons/ai";
 
 import PendingSyncListModal from "./PendingSyncListModal";
+import { didPathMarkSyncTaskComplete, getPathMarkSyncTask } from "./pathMarkSyncTask";
 
 import { Button, Badge } from "@/components/bakaui";
 import BApi from "@/sdk/BApi";
-import { BTaskStatus } from "@/sdk/constants";
 import { useBTasksStore } from "@/stores/bTasks";
 
 export interface PendingSyncButtonRef {
@@ -21,10 +21,6 @@ interface PendingSyncButtonProps {
   onSyncComplete?: () => void;
 }
 
-// Match PathMark sync task IDs
-const isPathMarkSyncTask = (taskId: string) =>
-  taskId === "SyncPathMarks" || taskId.startsWith("SyncPathMark_");
-
 const PendingSyncButton = forwardRef<PendingSyncButtonRef, PendingSyncButtonProps>(
   ({ buttonSize = "sm", className, onSyncComplete }, ref) => {
     const { t } = useTranslation();
@@ -33,10 +29,11 @@ const PendingSyncButton = forwardRef<PendingSyncButtonRef, PendingSyncButtonProp
     const [showPendingSyncModal, setShowPendingSyncModal] = useState(false);
 
     // Track previous task statuses to detect completion
-    const prevTaskStatusesRef = useRef<Map<string, BTaskStatus>>(new Map());
+    const prevTaskStatusRef = useRef<BTaskStatus>();
 
     // Watch BTask store for PathMark sync tasks
     const bTasks = useBTasksStore((state) => state.tasks);
+    const pathMarkSyncTask = getPathMarkSyncTask(bTasks);
 
     // Load pending sync count
     const loadPendingSyncCount = useCallback(async () => {
@@ -55,33 +52,16 @@ const PendingSyncButton = forwardRef<PendingSyncButtonRef, PendingSyncButtonProp
 
     // Auto-refresh when PathMark sync tasks complete
     useEffect(() => {
-      if (!bTasks) return;
+      const previousStatus = prevTaskStatusRef.current;
+      const currentStatus = pathMarkSyncTask?.status;
 
-      const prevStatuses = prevTaskStatusesRef.current;
-      let hasCompletedTask = false;
-
-      for (const task of bTasks as BTask[]) {
-        if (!isPathMarkSyncTask(task.id)) continue;
-
-        const prevStatus = prevStatuses.get(task.id);
-
-        // Check if task just completed (was running/not started, now completed)
-        if (
-          prevStatus !== undefined &&
-          (prevStatus === BTaskStatus.Running || prevStatus === BTaskStatus.NotStarted) &&
-          task.status === BTaskStatus.Completed
-        ) {
-          hasCompletedTask = true;
-        }
-
-        prevStatuses.set(task.id, task.status);
-      }
-
-      if (hasCompletedTask) {
+      if (didPathMarkSyncTaskComplete(previousStatus, currentStatus)) {
         loadPendingSyncCount();
         onSyncComplete?.();
       }
-    }, [bTasks, loadPendingSyncCount, onSyncComplete]);
+
+      prevTaskStatusRef.current = currentStatus;
+    }, [pathMarkSyncTask?.status, loadPendingSyncCount, onSyncComplete]);
 
     // Expose refresh method via ref
     useImperativeHandle(

--- a/src/web/src/pages/path-mark-config/components/PendingSyncListModal.tsx
+++ b/src/web/src/pages/path-mark-config/components/PendingSyncListModal.tsx
@@ -3,7 +3,6 @@
 import type { BakabaseAbstractionsModelsDomainPathMark } from "@/sdk/Api";
 import type { DestroyableProps } from "@/components/bakaui/types";
 import type { PathMarkSyncStatus as PathMarkSyncStatusType } from "@/sdk/constants";
-import type { BTask } from "@/core/models/BTask";
 
 import React, { useState, useEffect, useCallback } from "react";
 import { useTranslation } from "react-i18next";
@@ -16,10 +15,15 @@ import {
 } from "react-icons/ai";
 
 import SyncProgressModal from "./SyncProgressModal";
+import {
+  getPathMarkSyncProgress,
+  getPathMarkSyncTask,
+  isPathMarkSyncTaskActive,
+} from "./pathMarkSyncTask";
 
 import { Modal, Button, Chip, Spinner, Tooltip, CircularProgress } from "@/components/bakaui";
 import { HelpCenterButton } from "@/components/HelpCenter";
-import { PathMarkSyncStatus, PathMarkType, BTaskStatus } from "@/sdk/constants";
+import { PathMarkSyncStatus, PathMarkType } from "@/sdk/constants";
 import { useBakabaseContext } from "@/components/ContextProvider/BakabaseContextProvider";
 import BApi from "@/sdk/BApi";
 import { useBTasksStore } from "@/stores/bTasks";
@@ -101,9 +105,6 @@ const getMarkTypeColor = (type?: number) => {
   }
 };
 
-// Build task ID for a single mark sync
-const buildMarkTaskId = (markId: number) => `SyncPathMark_${markId}`;
-
 const PendingSyncListModal = ({
   visible = true,
   onClose,
@@ -116,8 +117,11 @@ const PendingSyncListModal = ({
   const [loading, setLoading] = useState(false);
   const [pendingMarks, setPendingMarks] = useState<BakabaseAbstractionsModelsDomainPathMark[]>([]);
 
-  // Watch BTask store for individual mark sync tasks
+  // Path-mark synchronization is represented by one global BTask.
   const bTasks = useBTasksStore((state) => state.tasks);
+  const pathMarkSyncTask = getPathMarkSyncTask(bTasks);
+  const isPathMarkSyncTaskRunning = isPathMarkSyncTaskActive(pathMarkSyncTask);
+  const pathMarkSyncProgress = getPathMarkSyncProgress(pathMarkSyncTask);
 
   // Watch PathMarks store for real-time status updates via SignalR
   const pathMarksStore = usePathMarksStore((state) => state.marks);
@@ -237,11 +241,6 @@ const PendingSyncListModal = ({
     }).length;
   }, [pendingMarks, pathMarksStore]);
 
-  // Get task for a specific mark
-  const getMarkTask = (markId: number): BTask | undefined => {
-    return bTasks?.find((t) => t.id === buildMarkTaskId(markId)) as BTask | undefined;
-  };
-
   return (
     <Modal
       footer={
@@ -313,10 +312,8 @@ const PendingSyncListModal = ({
               {/* Marks under this path */}
               <div className="flex flex-col gap-1 pl-4">
                 {group.marks.map((mark) => {
-                  const markTask = getMarkTask(mark.id!);
-                  const isTaskRunning =
-                    markTask?.status === BTaskStatus.Running ||
-                    markTask?.status === BTaskStatus.NotStarted;
+                  const isMarkSyncing = mark.syncStatus === PathMarkSyncStatus.Syncing;
+                  const showOverallProgress = isMarkSyncing && isPathMarkSyncTaskRunning;
                   const isPendingDelete = mark.syncStatus === PathMarkSyncStatus.PendingDelete;
 
                   return (
@@ -329,11 +326,7 @@ const PendingSyncListModal = ({
                       {/* Sync status icon */}
                       <Tooltip content={getSyncStatusLabel(mark.syncStatus, t)}>
                         <span className="flex items-center">
-                          {isTaskRunning ? (
-                            <Spinner className="w-4 h-4" size="sm" />
-                          ) : (
-                            getSyncStatusIcon(mark.syncStatus)
-                          )}
+                          {getSyncStatusIcon(mark.syncStatus)}
                         </span>
                       </Tooltip>
 
@@ -346,13 +339,24 @@ const PendingSyncListModal = ({
                       <span className="text-xs text-default-500">#{mark.priority}</span>
 
                       {/* Task progress if running */}
-                      {isTaskRunning && markTask && (
-                        <CircularProgress
-                          showValueLabel
-                          className="w-8"
-                          size="sm"
-                          value={markTask.percentage || 0}
-                        />
+                      {showOverallProgress && (
+                        <Tooltip
+                          content={
+                            pathMarkSyncProgress == null
+                              ? t("pathMarkConfig.status.syncing")
+                              : t("pathMarkConfig.status.overallSyncProgress", {
+                                  progress: Math.round(pathMarkSyncProgress),
+                                })
+                          }
+                        >
+                          <CircularProgress
+                            showValueLabel
+                            className="w-8"
+                            isIndeterminate={pathMarkSyncProgress == null}
+                            size="sm"
+                            value={pathMarkSyncProgress}
+                          />
+                        </Tooltip>
                       )}
 
                       {/* Error message */}
@@ -371,8 +375,8 @@ const PendingSyncListModal = ({
                       <Button
                         isIconOnly
                         color="primary"
-                        isDisabled={isPendingDelete || isTaskRunning}
-                        isLoading={isTaskRunning}
+                        isDisabled={isPendingDelete || isMarkSyncing}
+                        isLoading={isMarkSyncing}
                         size="sm"
                         variant="light"
                         onPress={() => handleSyncMark(mark)}

--- a/src/web/src/pages/path-mark-config/components/__tests__/pathMarkSyncTask.test.ts
+++ b/src/web/src/pages/path-mark-config/components/__tests__/pathMarkSyncTask.test.ts
@@ -1,0 +1,59 @@
+import type { BTask } from "@/core/models/BTask";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  didPathMarkSyncTaskComplete,
+  getPathMarkSyncProgress,
+  getPathMarkSyncTask,
+  isPathMarkSyncTaskActive,
+  PATH_MARK_SYNC_TASK_ID,
+} from "../pathMarkSyncTask";
+
+import { BTaskStatus } from "@/sdk/constants";
+
+const task = (id: string, status: BTaskStatus, percentage?: number) =>
+  ({ id, status, percentage }) as BTask;
+
+describe("path-mark synchronization task", () => {
+  it("uses only the global task and ignores legacy per-mark task ids", () => {
+    const legacyTask = task("SyncPathMark_42", BTaskStatus.Running, 75);
+    const globalTask = task(PATH_MARK_SYNC_TASK_ID, BTaskStatus.Running, 90);
+
+    expect(getPathMarkSyncTask([legacyTask])).toBeUndefined();
+    expect(getPathMarkSyncTask([legacyTask, globalTask])).toBe(globalTask);
+  });
+
+  it("treats every non-terminal global task status as active", () => {
+    expect(isPathMarkSyncTaskActive(task(PATH_MARK_SYNC_TASK_ID, BTaskStatus.NotStarted))).toBe(
+      true,
+    );
+    expect(isPathMarkSyncTaskActive(task(PATH_MARK_SYNC_TASK_ID, BTaskStatus.Paused))).toBe(true);
+    expect(isPathMarkSyncTaskActive(task(PATH_MARK_SYNC_TASK_ID, BTaskStatus.Cancelling))).toBe(
+      true,
+    );
+    expect(isPathMarkSyncTaskActive(task(PATH_MARK_SYNC_TASK_ID, BTaskStatus.Completed))).toBe(
+      false,
+    );
+  });
+
+  it("uses indeterminate progress until the global task reports a positive percentage", () => {
+    expect(
+      getPathMarkSyncProgress(task(PATH_MARK_SYNC_TASK_ID, BTaskStatus.Running)),
+    ).toBeUndefined();
+    expect(
+      getPathMarkSyncProgress(task(PATH_MARK_SYNC_TASK_ID, BTaskStatus.Running, 0)),
+    ).toBeUndefined();
+    expect(getPathMarkSyncProgress(task(PATH_MARK_SYNC_TASK_ID, BTaskStatus.Running, 87))).toBe(87);
+    expect(
+      getPathMarkSyncProgress(task(PATH_MARK_SYNC_TASK_ID, BTaskStatus.Completed, 100)),
+    ).toBeUndefined();
+  });
+
+  it("detects completion or cleanup only after an active task", () => {
+    expect(didPathMarkSyncTaskComplete(BTaskStatus.Running, BTaskStatus.Completed)).toBe(true);
+    expect(didPathMarkSyncTaskComplete(BTaskStatus.Paused, undefined)).toBe(true);
+    expect(didPathMarkSyncTaskComplete(BTaskStatus.Completed, undefined)).toBe(false);
+    expect(didPathMarkSyncTaskComplete(undefined, BTaskStatus.Completed)).toBe(false);
+  });
+});

--- a/src/web/src/pages/path-mark-config/components/pathMarkSyncTask.ts
+++ b/src/web/src/pages/path-mark-config/components/pathMarkSyncTask.ts
@@ -1,0 +1,41 @@
+import type { BTask } from "@/core/models/BTask";
+
+import { BTaskStatus } from "@/sdk/constants";
+
+export const PATH_MARK_SYNC_TASK_ID = "SyncPathMarks";
+
+const activeStatuses = new Set<BTaskStatus>([
+  BTaskStatus.NotStarted,
+  BTaskStatus.Running,
+  BTaskStatus.Paused,
+  BTaskStatus.Cancelling,
+  BTaskStatus.Pausing,
+  BTaskStatus.Resuming,
+]);
+
+export const getPathMarkSyncTask = (tasks?: BTask[]): BTask | undefined =>
+  tasks?.find((task) => task.id === PATH_MARK_SYNC_TASK_ID);
+
+export const isPathMarkSyncTaskActive = (task?: BTask): boolean =>
+  task != null && activeStatuses.has(task.status);
+
+/**
+ * Returns the real overall progress exposed by the single global path-mark sync task.
+ * Zero/missing progress is represented as undefined so callers can render an indeterminate
+ * indicator instead of implying that an individual mark has its own measurable task.
+ */
+export const getPathMarkSyncProgress = (task?: BTask): number | undefined => {
+  if (!isPathMarkSyncTaskActive(task) || task?.percentage == null || task.percentage <= 0) {
+    return undefined;
+  }
+
+  return Math.min(100, Math.max(0, task.percentage));
+};
+
+export const didPathMarkSyncTaskComplete = (
+  previousStatus?: BTaskStatus,
+  currentStatus?: BTaskStatus,
+): boolean =>
+  previousStatus != null &&
+  activeStatuses.has(previousStatus) &&
+  (currentStatus == null || currentStatus === BTaskStatus.Completed);


### PR DESCRIPTION
## Summary

- report localized path-mark synchronization phases through effect persistence, the search-index barrier, and mark-status cleanup; use the real global `SyncPathMarks` task in the UI
- coalesce adjacent search-index invalidations into bounded 4096-resource batches while preserving FIFO barriers, remove precedence, retry, and full-scan fallback semantics
- wait for the corresponding search-index prefix before rebuilding resource-profile mappings, evaluate each profile once per resource batch, retain invalidations arriving during an active task, and report localized progress
- keep profile mappings, priority order, and playable-file cache invalidation consistent for both resource and profile changes
- update the repository search-index guidance to match the new bounded batching model

## Root cause

Path-mark synchronization waited for all queued search-index work after reporting 80%, so a large update looked frozen even though it was still processing. The frontend also looked for per-mark task IDs that the backend never creates.

The search index queued one item per resource and repeatedly loaded full in-memory stores in batches of 100. At the same time, ResourceProfileIndex evaluated every profile once per changed resource, could read SearchIndex before the same change reached it, and could leave updates queued when they arrived after the active task had drained its snapshot.

## Verification

- backend build: succeeded with 0 errors
- path-mark synchronization combinations: 28 passed
- path-mark reference-value regressions: 9 passed
- path-mark progress barrier regression: 1 passed
- incremental search-index tests: 11 passed, including a 6000-resource barrier boundary
- resource-profile index tests: 12 passed; both new race/profile-change cases passed repeated runs
- resource search/filter tests: 29 passed
- property-value resource-count tests: 12 passed
- frontend Vitest suite: 22 files / 291 tests passed
- frontend production build: succeeded
- changed frontend files: ESLint reported 0 errors (4 pre-existing warnings)

Fixes #1333
Fixes #1334
Fixes #1335