### PR TITLE
fix(resource-filter): remove reserved choice count widths

### DIFF
--- a/src/web/src/components/ResourceFilter/__tests__/choiceResourceCount.test.tsx
+++ b/src/web/src/components/ResourceFilter/__tests__/choiceResourceCount.test.tsx
@@ -25,26 +25,27 @@ afterEach(async () => {
 });
 
 describe("filter choice resource count", () => {
-  it("keeps a mounted badge's slot width across digit changes, zero, and unavailable counts", async () => {
+  it("updates mounted counts at their natural width and removes zero or unavailable badges", async () => {
     const store = createChoiceResourceCountsStore();
 
-    store.publish({ counts: { choice: 1_000 }, reservedWidths: { choice: 7 } });
+    store.publish({ counts: { choice: 1_000 } });
     await act(async () => root.render(<ChoiceResourceCount choiceId="choice" store={store} />));
-    const badge = container.querySelector("span")!;
 
-    for (const count of [9, 10, 1_000, 0, undefined]) {
+    for (const count of [9, 10, 1_000, 0, undefined, 3]) {
       act(() =>
         store.publish({
           counts: count === undefined ? undefined : { choice: count },
-          reservedWidths: { choice: 7 },
         }),
       );
-      expect(container.querySelector("span")).toBe(badge);
-      expect(badge.style.width).toBe("7ch");
-      expect(badge.style.flexShrink).toBe("0");
-      expect(badge.style.whiteSpace).toBe("nowrap");
-      expect(badge.textContent).toBe(count ? `(${count.toLocaleString()})` : "");
-      expect(badge.getAttribute("aria-hidden")).toBe(String(!count));
+      if (count !== undefined && count > 0) {
+        const badge = container.querySelector("span")!;
+
+        expect(badge.style.width).toBe("");
+        expect(badge.style.minWidth).toBe("");
+        expect(badge.textContent).toBe(`(${count.toLocaleString()})`);
+      } else {
+        expect(container.innerHTML).toBe("");
+      }
     }
   });
 
@@ -52,27 +53,29 @@ describe("filter choice resource count", () => {
     const store = createChoiceResourceCountsStore();
     const counts = { choice: 9 };
 
-    store.publish({ counts, reservedWidths: { choice: 7 } });
+    store.publish({ counts });
     await act(async () => root.render(<ChoiceResourceCount choiceId="choice" store={store} />));
     const badge = container.querySelector("span")!;
 
     expect(badge.className).toContain("opacity-70");
-    act(() => store.publish({ counts, reservedWidths: { choice: 7 }, loading: true, stale: true }));
+    act(() => store.publish({ counts, loading: true, stale: true }));
+    expect(container.querySelector("span")).toBe(badge);
     expect(badge.textContent).toBe("(9)");
     expect(badge.className).toContain("opacity-40");
     expect(badge.title).toBe("property.reference.updatingCounts");
-    expect(badge.style.width).toBe("7ch");
+    expect(badge.style.width).toBe("");
 
-    act(() => store.publish({ counts, reservedWidths: { choice: 7 }, error: true, stale: true }));
+    act(() => store.publish({ counts, error: true, stale: true }));
+    expect(container.querySelector("span")).toBe(badge);
     expect(badge.textContent).toBe("(9)");
     expect(badge.title).toBe("property.reference.countsUpdateFailed");
     expect(badge.className).toContain("opacity-40");
   });
 
-  it("does not introduce placeholder badges without an assigned slot", async () => {
+  it("does not introduce placeholder badges while counts load", async () => {
     const store = createChoiceResourceCountsStore();
 
-    store.publish({ counts: { zero: 0 }, reservedWidths: { anotherChoice: 4 }, loading: true });
+    store.publish({ counts: { zero: 0 }, loading: true });
     await act(async () =>
       root.render(
         <>
@@ -144,7 +147,6 @@ describe("filter choice resource count", () => {
     const unsubscribe = store.subscribe(() => observed.push(store.getSnapshot()));
     const updated = {
       counts: { next: 10 },
-      reservedWidths: { next: 4 },
       loading: false,
       stale: false,
     };

--- a/src/web/src/components/ResourceFilter/__tests__/filterValueRenderer.test.tsx
+++ b/src/web/src/components/ResourceFilter/__tests__/filterValueRenderer.test.tsx
@@ -184,7 +184,7 @@ describe("filter value renderer", () => {
     state.filteredStatus.loading = false;
     await act(async () => root.render(<FilterValueRenderer property={property} />));
     expect(extra("choice", portalContainer).textContent).toBe("");
-    expect(badge("choice", portalContainer)!.style.width).toBe("3ch");
+    expect(badge("choice", portalContainer)).toBeNull();
 
     state.search = undefined;
     await act(async () => root.render(<FilterValueRenderer property={property} />));
@@ -194,14 +194,14 @@ describe("filter value renderer", () => {
   it("keeps global counts visible and availability unchanged during the first filtered request", async () => {
     state.globalCounts = { choice: 1_000, unused: 0 };
     await act(async () => root.render(<FilterValueRenderer property={property} />));
-    const width = badge("choice")!.style.width;
+    const previousBadge = badge("choice");
 
     state.search = { keyword: "new filter" };
     state.filteredStatus.loading = true;
     await act(async () => root.render(<FilterValueRenderer property={property} />));
 
     expect(extra("choice").textContent).toBe(`(${(1_000).toLocaleString()})`);
-    expect(badge("choice")!.style.width).toBe(width);
+    expect(badge("choice")).toBe(previousBadge);
     expect(badge("choice")!.title).toBe("property.reference.updatingCounts");
     expect(container.querySelector('[role="status"]')!.textContent).toBe(
       "property.reference.updatingCounts",
@@ -234,20 +234,23 @@ describe("filter value renderer", () => {
     expect(container.querySelector('[role="status"]')!.textContent).toBe("");
   });
 
-  it("preserves count widths as filtered values change digits or become zero", async () => {
+  it("displays compact filtered counts without reserving space for global totals", async () => {
     state.globalCounts = { choice: 1_000, unused: 0 };
     state.search = { keyword: "filter" };
     state.filteredCounts = { choice: 9, unused: 0 };
     await act(async () => root.render(<FilterValueRenderer property={property} />));
-    const width = `${(1_000).toLocaleString().length + 2}ch`;
-
-    expect(badge("choice")!.style.width).toBe(width);
+    expect(badge("choice")!.style.width).toBe("");
     expect(badge("unused")).toBeNull();
     for (const count of [10, 1_000, 0, 9]) {
       state.filteredCounts = { choice: count, unused: 0 };
       await act(async () => root.render(<FilterValueRenderer property={property} />));
       expect(extra("choice").textContent).toBe(count > 0 ? `(${count.toLocaleString()})` : "");
-      expect(badge("choice")!.style.width).toBe(width);
+      if (count > 0) {
+        expect(badge("choice")!.style.width).toBe("");
+        expect(badge("choice")!.style.minWidth).toBe("");
+      } else {
+        expect(badge("choice")).toBeNull();
+      }
       expect(option("choice").disabled).toBe(false);
       expect(option("unused").disabled).toBe(true);
     }
@@ -278,14 +281,14 @@ describe("filter value renderer", () => {
     state.search = { keyword: "first filter" };
     state.filteredCounts = { choice: 2, unused: 0 };
     await act(async () => root.render(<FilterValueRenderer property={property} />));
-    const width = badge("choice")!.style.width;
+    const previousBadge = badge("choice");
 
     state.search = { keyword: "failing filter" };
     state.filteredCounts = undefined;
     state.filteredStatus = { loading: false, error: true, stale: false };
     await act(async () => root.render(<FilterValueRenderer property={property} />));
     expect(extra("choice").textContent).toBe("(2)");
-    expect(badge("choice")!.style.width).toBe(width);
+    expect(badge("choice")).toBe(previousBadge);
     expect(badge("choice")!.title).toBe("property.reference.countsUpdateFailed");
     expect(option("choice").disabled).toBe(false);
     expect(option("unused").disabled).toBe(true);
@@ -296,7 +299,7 @@ describe("filter value renderer", () => {
     { field: "pool", changed: { pool: PropertyPool.Reserved } },
     { field: "type", changed: { type: PropertyType.MultipleChoice } },
   ])(
-    "isolates counts, width and captured extras when the property $field changes",
+    "isolates counts and captured extras when the property $field changes",
     async ({ changed }) => {
       state.globalCounts = { choice: 1_000, unused: 0 };
       await act(async () => root.render(<FilterValueRenderer property={property} />));
@@ -318,12 +321,8 @@ describe("filter value renderer", () => {
       state.globalStatus.loading = false;
       await act(async () => root.render(<FilterValueRenderer property={nextProperty} />));
       expect(extra("choice").textContent).toBe("(3)");
-      expect(badge("choice")!.style.width).toBe("3ch");
       expect(option("unused").disabled).toBe(false);
       expect(extra("choice", portalContainer).textContent).toBe(`(${(1_000).toLocaleString()})`);
-      expect(badge("choice", portalContainer)!.style.width).toBe(
-        `${(1_000).toLocaleString().length + 2}ch`,
-      );
       expect(option("unused", portalContainer).disabled).toBe(true);
     },
   );

--- a/src/web/src/components/ResourceFilter/components/Filter/ChoiceResourceCount.tsx
+++ b/src/web/src/components/ResourceFilter/components/Filter/ChoiceResourceCount.tsx
@@ -52,37 +52,16 @@ export default function ChoiceResourceCount({
   const { t } = useTranslation();
   const state = useChoiceResourceCounts(store);
   const count = state.counts?.[choiceId];
-  const reservedWidth = state.reservedWidths?.[choiceId];
-  const hasCount = count !== undefined && count > 0;
 
-  if (!hasCount && reservedWidth === undefined) return null;
+  if (count === undefined || count <= 0) return null;
   const statusKey = getStatusKey(state);
 
   return (
     <span
-      aria-hidden={!hasCount}
       className={`ml-1 text-xs tabular-nums ${state.loading || state.stale ? "opacity-40" : "opacity-70"}`}
-      style={
-        reservedWidth === undefined
-          ? undefined
-          : {
-              display: "inline-block",
-              width: `${reservedWidth}ch`,
-              textAlign: "right",
-              flexShrink: 0,
-              whiteSpace: "nowrap",
-              visibility: hasCount ? undefined : "hidden",
-            }
-      }
-      title={
-        hasCount
-          ? statusKey
-            ? t(statusKey)
-            : t("property.reference.resourceCount", { count })
-          : undefined
-      }
+      title={statusKey ? t(statusKey) : t("property.reference.resourceCount", { count })}
     >
-      {hasCount ? `(${count.toLocaleString()})` : undefined}
+      ({count.toLocaleString()})
     </span>
   );
 }

--- a/src/web/src/components/ResourceFilter/hooks/choiceResourceCountsStore.ts
+++ b/src/web/src/components/ResourceFilter/hooks/choiceResourceCountsStore.ts
@@ -2,8 +2,6 @@ import { useSyncExternalStore } from "react";
 
 export type ChoiceResourceCountsState = {
   counts?: Record<string, number>;
-  /** Count-slot widths in ch, including parentheses. */
-  reservedWidths?: Readonly<Record<string, number>>;
   loading?: boolean;
   error?: boolean;
   stale?: boolean;

--- a/src/web/src/components/ResourceFilter/hooks/useFilterChoiceCounts.ts
+++ b/src/web/src/components/ResourceFilter/hooks/useFilterChoiceCounts.ts
@@ -10,29 +10,6 @@ import {
   useReferenceValueResourceCounts,
 } from "@/hooks/useReferenceValueResourceCounts";
 
-const emptyWidths: Readonly<Record<string, number>> = {};
-
-/** Global totals bound filtered counts; keep slots from shrinking during consecutive edits. */
-function reserveWidths(
-  previous: Readonly<Record<string, number>>,
-  ...counts: (Record<string, number> | undefined)[]
-): Readonly<Record<string, number>> {
-  let updated: Record<string, number> | undefined;
-
-  for (const values of counts) {
-    for (const [id, count] of Object.entries(values ?? {})) {
-      if (count <= 0) continue;
-      const width = count.toLocaleString().length + 2;
-
-      if (width <= ((updated ?? previous)[id] ?? 0)) continue;
-      updated ??= { ...previous };
-      updated[id] = width;
-    }
-  }
-
-  return updated ?? previous;
-}
-
 /** Resource-count display and availability policies belong to the filter using the options. */
 export function useFilterChoiceCounts(property: ReferenceProperty, search?: SearchForm) {
   const globalUsage = useReferenceValueResourceCounts(property);
@@ -43,36 +20,26 @@ export function useFilterChoiceCounts(property: ReferenceProperty, search?: Sear
   const [retained, setRetained] = useState<{
     key: string;
     counts?: Record<string, number>;
-    widths: Readonly<Record<string, number>>;
   }>();
   const previous = retained?.key === propertyKey ? retained : undefined;
   // When clearing/reapplying criteria, use the last displayed result rather than an older
-  // filtered hook result. A different property never inherits these counts or widths.
+  // filtered hook result. A different property never inherits these counts.
   const counts = usage.counts && !usage.stale ? usage.counts : (previous?.counts ?? usage.counts);
-  const reservedWidths = useMemo(
-    () => reserveWidths(previous?.widths ?? emptyWidths, globalUsage.counts, counts),
-    [previous?.widths, globalUsage.counts, counts],
-  );
 
   useEffect(() => {
-    if (
-      retained?.key !== propertyKey ||
-      retained.counts !== counts ||
-      retained.widths !== reservedWidths
-    ) {
-      setRetained({ key: propertyKey, counts, widths: reservedWidths });
+    if (retained?.key !== propertyKey || retained.counts !== counts) {
+      setRetained({ key: propertyKey, counts });
     }
-  }, [propertyKey, counts, reservedWidths, retained]);
+  }, [propertyKey, counts, retained]);
 
   const state = useMemo(
     () => ({
       counts,
-      reservedWidths,
       loading: usage.loading,
       error: usage.error,
       stale: counts !== undefined && (usage.stale || counts !== usage.counts),
     }),
-    [counts, reservedWidths, usage.loading, usage.error, usage.stale, usage.counts],
+    [counts, usage.loading, usage.error, usage.stale, usage.counts],
   );
   const store = useMemo(createChoiceResourceCountsStore, [propertyKey]);
 


### PR DESCRIPTION
Resource-filter choices reserved space for the largest count, making options unnecessarily wide even when their current count was zero. Counts now use their natural text width, and zero or unavailable counts render no badge or gap. Previous counts remain visible while refreshed results are pending.

Removed the unused width bookkeeping and updated regression coverage for compact counts, refresh retention, and open option portals.

Validation:
- 35 relevant tests passed across count rendering, filter integration, and count queries.
- Scoped ESLint and the Vite production build passed.
- Browser measurements confirmed zero-count options match plain option widths, and smaller counts shrink naturally.

Fixes #1338
