### PR TITLE
fix(client): stop the client migrating a log database it does not have

### DIFF
--- a/src/apps/Bakabase.Client.Remoting/Components/ClientHost.cs
+++ b/src/apps/Bakabase.Client.Remoting/Components/ClientHost.cs
@@ -78,6 +78,19 @@ public class ClientHost(IGuiAdapter guiAdapter, ISystemService systemService)
             ? AppService.DefaultAppDataDirectory
             : EffectiveAppDataResolver.Resolve(AppService.DefaultAppDataDirectory).DataDir;
 
+    /// <summary>
+    /// There is no log database here, so the startup step that migrates one must not run.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="ClientStartup"/> composes its own services rather than deriving from
+    /// <c>AppStartup</c>, so nothing registers <c>LogDbContext</c> — deliberately: this
+    /// process keeps no database at all, and <see cref="Diagnostics.ClientLogReader"/>
+    /// reads the client's log back out of the Serilog file instead. Left at the inherited
+    /// default, the migration step resolved a context nobody registered and took the whole
+    /// launch down with it.
+    /// </remarks>
+    protected override bool HasLogDatabase => false;
+
     protected override string DisplayName => "Bakabase Client";
 
     protected override IHostBuilder CreateHostBuilder(params string[] args) =>

--- a/src/tests/Bakabase.Tests/RemoteAccess/ClientPipelineTests.cs
+++ b/src/tests/Bakabase.Tests/RemoteAccess/ClientPipelineTests.cs
@@ -10,12 +10,16 @@ using System.Threading.Tasks;
 using Bakabase.Abstractions.Models.Domain.Constants;
 using Bakabase.Client.Remoting.Abstractions;
 using Bakabase.Client.Remoting.Abstractions.Models;
+using Bakabase.Client.Remoting.Components;
 using Bakabase.Client.Remoting.Components.Diagnostics;
 using Bakabase.Client.Remoting.Components.Forwarding;
 using Bakabase.Client.Remoting.Components.Shell;
 using Bakabase.Client.Remoting.Components.Updating;
 using Bakabase.Client.Remoting.Components.UserMachine;
+using Bakabase.Infrastructures.Components.App;
+using Bakabase.Infrastructures.Components.Orm.Log;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -522,5 +526,43 @@ public class ClientPipelineTests
 
         Assert.AreEqual(HttpStatusCode.BadRequest, response.StatusCode);
         Assert.IsFalse(response.Headers.Contains("X-Bakabase-Client"));
+    }
+
+    // ---- composition ----
+
+    [TestMethod]
+    public void The_client_keeps_no_database()
+    {
+        // ClientStartup composes its own services rather than deriving from AppStartup,
+        // so nothing here registers a DbContext. That is the point of the flavour — the
+        // client's log is read back out of the Serilog file by ClientLogReader, and there
+        // is no library to store.
+        Assert.IsNull(_host.Services.GetService<LogDbContext>());
+        Assert.IsNull(_host.Services.GetService<DbContext>());
+    }
+
+    /// <summary>
+    /// Reads the host's own answer about the database without starting one.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="AppHost"/>'s constructor only assigns its two arguments, so a probe
+    /// costs nothing and touches no application data.
+    /// </remarks>
+    private sealed class HostProbe() : ClientHost(null!, null!)
+    {
+        public bool ClaimsALogDatabase => HasLogDatabase;
+    }
+
+    [TestMethod]
+    public void The_client_host_does_not_claim_a_log_database()
+    {
+        // The crash this pins: AppHost's startup sequence migrates LogDbContext, and the
+        // client inherited that step while registering no such context. The launch died
+        // on a NullReferenceException from inside a SQLite migration — a stack naming the
+        // database layer for what was purely a question of which host this is.
+        //
+        // Paired with the assertion above on purpose: one says the client has no database,
+        // the other says the host knows it. Either alone lets them drift back apart.
+        Assert.IsFalse(new HostProbe().ClaimsALogDatabase);
     }
 }


### PR DESCRIPTION
> **Merge order**: anobaka/Bakabase.Infrastructures#4 must merge first, and its branch must not be deleted until it does. The submodule pointer here is `a3715f4`.

## The bug

Reported from a real launch of the thin client:

```
System.NullReferenceException: Object reference not set to an instance of an object.
   at Bakabase.Infrastructures.Components.Orm.SqliteExtensions.MigrateSqliteDbContexts[TDbContext](IServiceProvider serviceProvider)
   at Bakabase.Infrastructures.Components.App.AppHost.<>c__DisplayClass58_1.<<Start>b__5>d.MoveNext()
```

`AppHost`'s custom-progress block migrates `LogDbContext`, which `AppStartup` registers. `ClientStartup` composes its own services instead of deriving from `AppStartup` — deliberately, since this process keeps no database and reads its own log back out of the Serilog file through `ClientLogReader`. So nothing registered one, the step resolved null, and the next line dereferenced it.

The plan for this flavour said the client skips backup, migration and the custom progresses, and `MigrateDb` and `ExecuteCustomProgress` were already `virtual` no-ops it inherits. This one call was the exception: hard-coded, with no seam to turn it off.

## The fix

The submodule exposes `HasLogDatabase` (`true` by default, so the all-in-one is untouched) and `ClientHost` answers `false`.

I checked every other service that block resolves against the client's container rather than assuming there was no second landmine:

| resolution | client |
|---|---|
| `AppService`, `IBOptionsManager<AppOptions>` | resolved before this point — and did succeed, which is why the launch reached the migration at all |
| `IEnumerable<IMigrator>` | resolves empty |
| `MigrateDb`, `ExecuteCustomProgress` | `virtual` no-ops |
| `SimpleJobManager` | fetched with `GetService`, null-checked |

## Tests

Two, deliberately paired:

- `The_client_keeps_no_database` — the running client host resolves neither `LogDbContext` nor `DbContext`
- `The_client_host_does_not_claim_a_log_database` — `ClientHost.HasLogDatabase` is false

One says the client has no database, the other says the host knows it. Either alone lets the two drift apart again.

## Verification

- full solution build: 0 errors
- `Bakabase.Tests`: **1074 passed / 0 failed** (1072 before, plus the two above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PVV1onwwDrwMQXq7fdgRXH

---
_Generated by [Claude Code](https://claude.ai/code/session_01PVV1onwwDrwMQXq7fdgRXH)_