### PR TITLE
fix: read the timestamps the server actually sends

### DIFF
--- a/src/apps/Bakabase.Client.Remoting/Components/Connection/ClientPairingService.cs
+++ b/src/apps/Bakabase.Client.Remoting/Components/Connection/ClientPairingService.cs
@@ -72,12 +72,6 @@ public interface IClientPairingService
 /// </remarks>
 public sealed class ClientPairingService(HttpClient http, IClientConnectionStore store) : IClientPairingService
 {
-    private static readonly JsonSerializerOptions Json = new()
-    {
-        PropertyNameCaseInsensitive = true,
-        Converters = {new JsonStringEnumConverter()}
-    };
-
     public async Task<ClientPairingResult> PairWithCodeAsync(string baseAddress, string code,
         CancellationToken ct = default)
     {
@@ -200,7 +194,7 @@ public sealed class ClientPairingService(HttpClient http, IClientConnectionStore
         try
         {
             return (await JsonSerializer.DeserializeAsync<Envelope<T>>(
-                await response.Content.ReadAsStreamAsync(ct), Json, ct))?.Data;
+                await response.Content.ReadAsStreamAsync(ct), ServerJson.Options, ct))?.Data;
         }
         catch (JsonException)
         {

--- a/src/apps/Bakabase.Client.Remoting/Components/Connection/ServerConnector.cs
+++ b/src/apps/Bakabase.Client.Remoting/Components/Connection/ServerConnector.cs
@@ -37,12 +37,6 @@ public sealed class ServerConnector(HttpClient http, ServerClock clock) : IServe
 
     public const int MaxSupportedProtocolVersion = RemoteAccessProtocol.CurrentVersion;
 
-    private static readonly JsonSerializerOptions Json = new()
-    {
-        PropertyNameCaseInsensitive = true,
-        Converters = {new JsonStringEnumConverter()}
-    };
-
     public async Task<ServerHandshakeResult> HandshakeAsync(string baseAddress, CancellationToken ct = default)
     {
         if (!Uri.TryCreate(Normalize(baseAddress), UriKind.Absolute, out var root) ||
@@ -89,7 +83,7 @@ public sealed class ServerConnector(HttpClient http, ServerClock clock) : IServe
         try
         {
             payload = (await JsonSerializer.DeserializeAsync<Envelope<ServerInfoPayload>>(
-                await response.Content.ReadAsStreamAsync(ct), Json, ct))?.Data;
+                await response.Content.ReadAsStreamAsync(ct), ServerJson.Options, ct))?.Data;
         }
         catch (JsonException e)
         {

--- a/src/apps/Bakabase.Client.Remoting/Components/Connection/ServerJson.cs
+++ b/src/apps/Bakabase.Client.Remoting/Components/Connection/ServerJson.cs
@@ -1,0 +1,76 @@
+using System.Globalization;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Bakabase.Client.Remoting.Components.Connection;
+
+/// <summary>
+/// How this client reads what a Bakabase server sends.
+/// </summary>
+/// <remarks>
+/// <para>
+/// One set of options rather than an identical copy beside every caller. The copies were
+/// already identical; what they were missing, they were missing in unison, and nothing
+/// would have told the next one to catch up.
+/// </para>
+/// <para>
+/// The server serializes with Newtonsoft under
+/// <c>DateFormatString = "yyyy-MM-dd HH:mm:ss.fff"</c> — a space where ISO 8601 puts a
+/// <c>T</c>, and no offset at all. System.Text.Json reads only ISO 8601, so every
+/// response carrying a timestamp threw before <see cref="ServerDateTimeConverter"/>
+/// existed, and the throw surfaced as "not a Bakabase server". The converter is
+/// registered here, once, for that reason.
+/// </para>
+/// </remarks>
+public static class ServerJson
+{
+    public static readonly JsonSerializerOptions Options = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        Converters =
+        {
+            // The server writes enums as numbers; this reads both, so a server that ever
+            // switches to names does not become unreadable.
+            new JsonStringEnumConverter(),
+            new ServerDateTimeConverter()
+        }
+    };
+}
+
+/// <summary>
+/// Reads the timestamps a Bakabase server writes, and writes ISO 8601 back.
+/// </summary>
+/// <remarks>
+/// Registered for <see cref="DateTime"/>; System.Text.Json routes <c>DateTime?</c>
+/// through it too, handling the null itself.
+/// <para>
+/// Reading goes through <see cref="ServerClock.ParseServerTime"/> so there is exactly one
+/// answer to "what does a server timestamp mean" — including the part that is easy to get
+/// wrong twice: the server stamps <c>DateTime.UtcNow</c> and then drops the marker saying
+/// so, so a reader that does not assume UTC is silently off by its own offset.
+/// </para>
+/// <para>
+/// Writing is plain ISO 8601 with the offset present. Newtonsoft reads that without
+/// complaint, so a request body this client sends needs no matching quirk.
+/// </para>
+/// </remarks>
+public sealed class ServerDateTimeConverter : JsonConverter<DateTime>
+{
+    public override DateTime Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        var raw = reader.TokenType == JsonTokenType.String ? reader.GetString() : null;
+        var parsed = ServerClock.ParseServerTime(raw);
+
+        if (parsed == null)
+        {
+            throw new JsonException(
+                $"'{raw}' is not a timestamp this client can read. Bakabase servers write " +
+                "'yyyy-MM-dd HH:mm:ss.fff' in UTC, and ISO 8601 is accepted too.");
+        }
+
+        return parsed.Value;
+    }
+
+    public override void Write(Utf8JsonWriter writer, DateTime value, JsonSerializerOptions options) =>
+        writer.WriteStringValue(value.ToUniversalTime().ToString("O", CultureInfo.InvariantCulture));
+}

--- a/src/apps/Bakabase.Client.Remoting/Components/Connection/UpstreamApi.cs
+++ b/src/apps/Bakabase.Client.Remoting/Components/Connection/UpstreamApi.cs
@@ -90,12 +90,6 @@ public sealed record UpstreamPlaylistSnapshot(BatchPlayPlaylistSnapshot? Snapsho
 
 public sealed class UpstreamApi(HttpClient http, IUpstreamTarget target) : IUpstreamApi
 {
-    private static readonly JsonSerializerOptions Json = new()
-    {
-        PropertyNameCaseInsensitive = true,
-        Converters = {new JsonStringEnumConverter()}
-    };
-
     public async Task<UpstreamResource?> GetResourceAsync(int id, CancellationToken ct = default)
     {
         // /resource/keys rather than a per-id route, because it is the one the server
@@ -200,7 +194,7 @@ public sealed class UpstreamApi(HttpClient http, IUpstreamTarget target) : IUpst
             }
 
             return (await JsonSerializer.DeserializeAsync<Envelope<T>>(
-                await response.Content.ReadAsStreamAsync(ct), Json, ct))?.Data;
+                await response.Content.ReadAsStreamAsync(ct), ServerJson.Options, ct))?.Data;
         }
         catch (Exception e) when (e is HttpRequestException or JsonException or TaskCanceledException &&
                                   !ct.IsCancellationRequested)
@@ -236,7 +230,7 @@ public sealed class UpstreamApi(HttpClient http, IUpstreamTarget target) : IUpst
             }
 
             return await JsonSerializer.DeserializeAsync<Envelope<T>>(
-                await response.Content.ReadAsStreamAsync(ct), Json, ct);
+                await response.Content.ReadAsStreamAsync(ct), ServerJson.Options, ct);
         }
         catch (Exception e) when (e is HttpRequestException or JsonException or TaskCanceledException &&
                                   !ct.IsCancellationRequested)

--- a/src/apps/Bakabase.Client.Remoting/Components/Forwarding/UpstreamContextProbe.cs
+++ b/src/apps/Bakabase.Client.Remoting/Components/Forwarding/UpstreamContextProbe.cs
@@ -20,12 +20,6 @@ public sealed class UpstreamContextProbe(HttpClient http, IUpstreamTarget target
 {
     public static readonly TimeSpan CacheLifetime = TimeSpan.FromSeconds(5);
 
-    private static readonly JsonSerializerOptions Json = new()
-    {
-        PropertyNameCaseInsensitive = true,
-        Converters = {new JsonStringEnumConverter()}
-    };
-
     private readonly Func<DateTime> _now = now ?? (() => DateTime.UtcNow);
     private readonly Lock _gate = new();
     private UpstreamContext? _cached;
@@ -77,7 +71,7 @@ public sealed class UpstreamContextProbe(HttpClient http, IUpstreamTarget target
             }
 
             var payload = (await JsonSerializer.DeserializeAsync<Envelope<ContextPayload>>(
-                await response.Content.ReadAsStreamAsync(ct), Json, ct))?.Data;
+                await response.Content.ReadAsStreamAsync(ct), ServerJson.Options, ct))?.Data;
 
             return payload == null ? null : new UpstreamContext(payload.Mode, payload.Paired);
         }

--- a/src/tests/Bakabase.Tests/RemoteAccess/ClientConnectionTests.cs
+++ b/src/tests/Bakabase.Tests/RemoteAccess/ClientConnectionTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Net;
 using System.Net.Http;
@@ -61,11 +62,26 @@ public class ClientConnectionTests
     private static HttpResponseMessage Json(string body, HttpStatusCode status = HttpStatusCode.OK) =>
         new(status) {Content = new StringContent(body, Encoding.UTF8, "application/json")};
 
+    /// <summary>
+    /// Shaped like what a Bakabase server actually puts on the wire, not like what is
+    /// convenient to write here.
+    /// </summary>
+    /// <remarks>
+    /// Two details are load-bearing, and both used to be wrong in a way that let the whole
+    /// handshake pass its tests while failing against every real server. <c>mode</c> is a
+    /// <b>number</b>: the server serializes enums as integers. <c>serverTime</c> is
+    /// <c>yyyy-MM-dd HH:mm:ss.fff</c> in UTC with no marker saying so — Newtonsoft's
+    /// configured format — and not the ISO 8601 this helper used to invent.
+    /// <see cref="A_real_servers_answer_is_understood"/> pins the shape against a verbatim
+    /// capture so a future edit here cannot quietly drift away from it again.
+    /// </remarks>
     private static string ServerInfo(int protocolVersion = 1, RemoteAccessMode mode = RemoteAccessMode.Enabled,
-        string? serverTime = null) =>
+        DateTime? serverTime = null) =>
         "{\"code\":0,\"data\":{\"id\":\"server-1\",\"name\":\"Desk\",\"appVersion\":\"1.2.3\"," +
-        $"\"protocolVersion\":{protocolVersion},\"mode\":\"{mode}\",\"pairingSupported\":true" +
-        (serverTime == null ? "" : $",\"serverTime\":\"{serverTime}\"") +
+        $"\"protocolVersion\":{protocolVersion},\"mode\":{(int) mode},\"pairingSupported\":true" +
+        (serverTime == null
+            ? ""
+            : $",\"serverTime\":\"{serverTime.Value.ToString("yyyy-MM-dd HH:mm:ss.fff", CultureInfo.InvariantCulture)}\"") +
         "}}";
 
     private static string PairingFailureBody(PairingFailure failure) =>
@@ -175,6 +191,40 @@ public class ClientConnectionTests
     }
 
     [TestMethod]
+    public async Task A_real_servers_answer_is_understood()
+    {
+        // Captured verbatim from 2.4.0-beta.242 answering GET /remote-access/server-info
+        // on loopback. Not reformatted, not tidied: every other test here builds its own
+        // JSON, and for a while all of them agreed with each other and none of them
+        // agreed with the server.
+        //
+        // What that cost: serverTime is "yyyy-MM-dd HH:mm:ss.fff", the format Newtonsoft
+        // is configured with on the server side, and System.Text.Json reads only ISO 8601.
+        // It threw on every real handshake, the throw was caught as "something answered,
+        // but it is not a Bakabase server", and the client could not reach any server at
+        // all. Note "mode":2 as well — enums go out as numbers.
+        const string captured =
+            "{\"data\":{\"id\":\"a0e15595186046fbb2f5c27643c8007a\",\"name\":\"ANOBAKA-HOME\"," +
+            "\"appVersion\":\"2.4.0-beta.242\",\"protocolVersion\":1,\"mode\":2," +
+            "\"pairingSupported\":true,\"serverTime\":\"2026-09-12 09:22:29.278\"}," +
+            "\"code\":0,\"message\":null}";
+
+        _handler.Respond = _ => Json(captured);
+
+        var result = await _connector.HandshakeAsync("192.168.1.5:34567");
+
+        Assert.AreEqual(ServerHandshakeOutcome.Ok, result.Outcome, result.Detail);
+        Assert.AreEqual("a0e15595186046fbb2f5c27643c8007a", result.Server!.Id);
+        Assert.AreEqual("ANOBAKA-HOME", result.Server.Name);
+        Assert.AreEqual(RemoteAccessMode.Unrestricted, result.Server.Mode);
+        Assert.IsTrue(result.Server.PairingSupported);
+
+        // Read as UTC, because that is what the server stamped and then forgot to say.
+        Assert.AreEqual(new DateTime(2026, 9, 12, 9, 22, 29, 278, DateTimeKind.Utc),
+            result.Server.ServerTime!.Value.ToUniversalTime());
+    }
+
+    [TestMethod]
     public async Task A_version_mismatch_says_which_side_has_to_move()
     {
         // "Incompatible" would leave the user guessing which thing to update.
@@ -192,7 +242,7 @@ public class ClientConnectionTests
     {
         // Without this a machine with a wrong clock has every later request refused as
         // expired, which looks exactly like a broken pairing.
-        _handler.Respond = _ => Json(ServerInfo(serverTime: "2026-01-01T12:07:00Z"));
+        _handler.Respond = _ => Json(ServerInfo(serverTime: _now.AddMinutes(7)));
 
         await _connector.HandshakeAsync("192.168.1.5:34567");
 

--- a/src/web/src/core/__tests__/serverTime.test.ts
+++ b/src/web/src/core/__tests__/serverTime.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+
+import { millisecondsUntil, minutesUntil, parseServerTime } from "../serverTime";
+
+/**
+ * Reading what the server actually sends.
+ *
+ * The bug these pin: `new Date("2026-09-12 09:22:29.278")` is read as *local* time, but
+ * the server stamped it with `DateTime.UtcNow` and its serializer dropped the marker
+ * saying so. East of Greenwich that put every deadline hours in the past — a pairing
+ * code was cleared from the page the instant it was issued, and the minutes left read 0
+ * for a code with a full ten minutes to run.
+ */
+describe("reading a server timestamp", () => {
+  // Captured verbatim from 2.4.0-beta.242's /remote-access/server-info.
+  const CAPTURED = "2026-09-12 09:22:29.278";
+  const CAPTURED_UTC = Date.UTC(2026, 8, 12, 9, 22, 29, 278);
+
+  it("takes a timestamp with no zone as UTC", () => {
+    expect(parseServerTime(CAPTURED)?.getTime()).toBe(CAPTURED_UTC);
+
+    // Whatever zone the test machine is in, the answer is the same instant. Written with
+    // an explicit offset so the assertion cannot pass by accident on a UTC runner while
+    // failing on the developer's laptop.
+    expect(parseServerTime(CAPTURED)?.toISOString()).toBe("2026-09-12T09:22:29.278Z");
+
+    // Seconds-only and a T separator are the same shape, still zoneless.
+    expect(parseServerTime("2026-09-12T09:22:29")?.toISOString()).toBe("2026-09-12T09:22:29.000Z");
+  });
+
+  it("takes a timestamp that states its zone at its word", () => {
+    expect(parseServerTime("2026-09-12T09:22:29.278Z")?.getTime()).toBe(CAPTURED_UTC);
+    expect(parseServerTime("2026-09-12T17:22:29.278+08:00")?.getTime()).toBe(CAPTURED_UTC);
+  });
+
+  it("answers null rather than an Invalid Date", () => {
+    expect(parseServerTime(undefined)).toBeNull();
+    expect(parseServerTime(null)).toBeNull();
+    expect(parseServerTime("")).toBeNull();
+    expect(parseServerTime("   ")).toBeNull();
+    expect(parseServerTime("not a time")).toBeNull();
+  });
+
+  it("counts down to a deadline instead of past it", () => {
+    const now = CAPTURED_UTC;
+
+    // Ten minutes out reads as ten minutes, not as zero — which is what the page showed
+    // for every live pairing code before this.
+    expect(minutesUntil("2026-09-12 09:32:29.278", now)).toBe(10);
+    expect(millisecondsUntil("2026-09-12 09:32:29.278", now)).toBe(600000);
+
+    // Rounded up, so the last partial minute of a live code still reads 1.
+    expect(minutesUntil("2026-09-12 09:22:59.278", now)).toBe(1);
+  });
+
+  it("treats what it cannot read, and what has passed, as over", () => {
+    const now = CAPTURED_UTC;
+
+    expect(millisecondsUntil("2026-09-12 09:12:29.278", now)).toBe(0);
+    expect(minutesUntil("2026-09-12 09:12:29.278", now)).toBe(0);
+
+    // Unreadable answers "over" rather than "forever": a caller shows an expired state
+    // instead of offering something that no longer works.
+    expect(millisecondsUntil("not a time", now)).toBe(0);
+    expect(millisecondsUntil(undefined, now)).toBe(0);
+  });
+});

--- a/src/web/src/core/serverTime.ts
+++ b/src/web/src/core/serverTime.ts
@@ -1,0 +1,54 @@
+/**
+ * Reading the timestamps the server sends.
+ *
+ * The server serializes with Newtonsoft under
+ * `DateFormatString = "yyyy-MM-dd HH:mm:ss.fff"` — a space where ISO 8601 puts a `T`,
+ * and no offset at all, even though the value is `DateTime.UtcNow`. `new Date()` reads
+ * a string in that shape as *local* time, so east of Greenwich every server timestamp
+ * lands hours in the past. That is not a cosmetic drift: a freshly issued pairing code
+ * was born already expired and vanished from the page, and "expires in N minutes" read
+ * 0 forever.
+ *
+ * The desktop client hit the same format from the other side — its JSON reader rejected
+ * it outright. Both now go through one deliberate answer to "what does a server
+ * timestamp mean", rather than each guessing.
+ */
+
+/** `2026-09-12 09:22:29.278` or `2026-09-12T09:22:29`, with nothing saying which zone. */
+const NAKED = /^\d{4}-\d{2}-\d{2}[ T]\d{2}:\d{2}:\d{2}(\.\d+)?$/;
+
+/**
+ * The instant a server timestamp refers to, or null when it is not one.
+ *
+ * A value that already carries a zone (`Z`, `+08:00`) is taken at its word; only the
+ * naked form is assumed UTC, which is what the server means by it.
+ */
+export const parseServerTime = (value?: string | null): Date | null => {
+  const raw = value?.trim();
+
+  if (!raw) {
+    return null;
+  }
+
+  const normalized = NAKED.test(raw) ? `${raw.replace(" ", "T")}Z` : raw;
+  const parsed = new Date(normalized);
+
+  return Number.isNaN(parsed.getTime()) ? null : parsed;
+};
+
+/**
+ * Milliseconds from `now` until a server timestamp, never negative.
+ *
+ * Returns 0 for an unreadable value, which reads as "already over" — the safe direction
+ * for a deadline: a caller shows an expired state rather than offering something that
+ * no longer works.
+ */
+export const millisecondsUntil = (value?: string | null, now: number = Date.now()): number => {
+  const at = parseServerTime(value);
+
+  return at == null ? 0 : Math.max(0, at.getTime() - now);
+};
+
+/** Whole minutes until a server timestamp, rounded up so a live deadline never reads 0. */
+export const minutesUntil = (value?: string | null, now: number = Date.now()): number =>
+  Math.ceil(millisecondsUntil(value, now) / 60000);

--- a/src/web/src/pages/ai-cache/index.tsx
+++ b/src/web/src/pages/ai-cache/index.tsx
@@ -26,6 +26,7 @@ import { Modal, toast } from "@/components/bakaui";
 import { useBakabaseContext } from "@/components/ContextProvider/BakabaseContextProvider";
 import BApi from "@/sdk/BApi";
 import LlmProviderSelector, { useLlmProviders } from "@/components/LlmProviderSelector";
+import { millisecondsUntil, parseServerTime } from "@/core/serverTime";
 
 type CacheEntry = BakabaseModulesAIModelsDbLlmCallCacheEntryDbModel;
 
@@ -111,13 +112,15 @@ const AiCachePage = () => {
   const isExpired = (entry: CacheEntry) => {
     if (!entry.expiresAt) return false;
 
-    return new Date(entry.expiresAt) < new Date();
+    // Through parseServerTime: the server's timestamps carry no zone, and reading them
+    // as local time marked every entry expired hours early east of Greenwich.
+    return millisecondsUntil(entry.expiresAt) <= 0;
   };
 
-  const formatTime = (iso?: string) => {
-    if (!iso) return "-";
+  const formatTime = (serverTime?: string) => {
+    const at = parseServerTime(serverTime);
 
-    return new Date(iso).toLocaleString();
+    return at == null ? "-" : at.toLocaleString();
   };
 
   const formatJson = (json: string) => {

--- a/src/web/src/pages/configuration/components/RemoteAccess/index.tsx
+++ b/src/web/src/pages/configuration/components/RemoteAccess/index.tsx
@@ -17,6 +17,7 @@ import { RemoteAccessMode, RemoteDevicePlatform } from "@/sdk/constants";
 import { Button, Chip, Input, Modal, Select, Snippet, Switch } from "@/components/bakaui";
 import { useBakabaseContext } from "@/components/ContextProvider/BakabaseContextProvider";
 import SettingsSection from "@/pages/configuration/components/SettingsSection";
+import { millisecondsUntil, minutesUntil } from "@/core/serverTime";
 import { useIsPureClient, useRemoteAccessStore } from "@/stores/remoteAccess";
 
 interface RemoteAccessProps {
@@ -101,9 +102,12 @@ const RemoteAccess: React.FC<RemoteAccessProps> = ({ query }) => {
     return () => clearInterval(timer);
   }, [hasLiveState, load]);
 
-  // Drop the digits the moment they stop working, so nobody types a dead code.
+  // Drop the digits the moment they stop working, so nobody types a dead code. Read
+  // through parseServerTime: the server's timestamps carry no zone, and taking them as
+  // local time made a code look expired the instant it was issued — the page cleared it
+  // before anyone could read it.
   useEffect(() => {
-    if (issuedCode && new Date(issuedCode.expiresAt).getTime() <= now) {
+    if (issuedCode && millisecondsUntil(issuedCode.expiresAt, now) <= 0) {
       setIssuedCode(undefined);
     }
   }, [issuedCode, now]);
@@ -191,13 +195,7 @@ const RemoteAccess: React.FC<RemoteAccessProps> = ({ query }) => {
     });
   };
 
-  const minutesLeft = (isoTime?: string | null) => {
-    if (!isoTime) {
-      return 0;
-    }
-
-    return Math.max(0, Math.ceil((new Date(isoTime).getTime() - now) / 60000));
-  };
+  const minutesLeft = (serverTime?: string | null) => minutesUntil(serverTime, now);
 
   const items: SettingItem[] = [
     {


### PR DESCRIPTION
Closes #1348

## One root cause

The server serializes with Newtonsoft under `DateFormatString = "yyyy-MM-dd HH:mm:ss.fff"` — a space where ISO 8601 puts a `T`, and no offset at all, though the value is `DateTime.UtcNow`. A real answer from 2.4.0-beta.242:

```json
{"data":{"id":"…","name":"ANOBAKA-HOME","appVersion":"2.4.0-beta.242",
"protocolVersion":1,"mode":2,"pairingSupported":true,
"serverTime":"2026-09-12 09:22:29.278"},"code":0,"message":null}
```

Both clients read it wrong, in opposite ways.

## The thin client could reach no server at all

`ServerConnector` hands that string to `System.Text.Json` as a `DateTime`, and System.Text.Json reads **only** ISO 8601. It threw on every real handshake, the throw was caught as `NotBakabase` (`ServerConnector.cs:94`, comment: *"Something is listening on that port; it just is not this."*), and the user saw **"Something answered, but it is not a Bakabase server."** — pointing at a server that was answering perfectly.

Clock synchronisation went with it: no `serverTime` parsed, so the offset stayed zero and every signed request was timed against an unchecked local clock.

Two things hid it:

- **`ServerClock.ParseServerTime` already existed for exactly this**, doc comment and all, and was called from nowhere. The payload was typed `DateTime?`, so System.Text.Json took the field before the helper could.
- **The tests were written from imagination.** The stub built `"mode":"Enabled"` where the server sends `2`, and the one case exercising `serverTime` invented ISO 8601. Every test agreed with every other test, and none agreed with the server.

## The web cleared the pairing code before anyone could read it

`new Date("2026-09-12 09:22:29.278")` is read as **local** time, so east of Greenwich every deadline landed hours in the past:

- the page's own cleanup judged a freshly issued code expired and dropped it — which is why the code was never visible even once, only the reissue button
- `minutesLeft` read 0, hence *"已有一个有效配对码 —— 0 分钟后过期"* about a code with ten minutes to run

The AI cache page compared expiry the same way.

## The fix

| | |
|---|---|
| Client | One `ServerJson.Options` replaces four identical, separately maintained copies, registering a converter that reads the server's format through `ServerClock.ParseServerTime` |
| Web | `core/serverTime.ts` parses a zoneless timestamp as UTC; used by the pairing code, the pending requests and the AI cache page |
| Tests | The stub now emits what goes on the wire (`"mode":2`, the real `serverTime` format), and a new case replays a **verbatim capture** |

Writing stays ISO 8601 with the offset present — Newtonsoft reads that without complaint, so nothing this client sends needs a matching quirk.

## Verification

**Reproduced before fixing.** With the client-side change stashed, the new case failed with exactly what the user hit:

```
Assert.AreEqual failed. Expected:<Ok>. Actual:<NotBakabase>.
The JSON value could not be converted to ServerConnector+ServerInfoPayload.
Path: $.data.serverTime
```

and `The_handshake_is_where_the_clock_offset_comes_from` failed alongside it (offset 0, expected 7) once the stub emitted the real format — the clock bug the old stub had been hiding.

With the fix:

- `Bakabase.Tests`: **1075 passed / 0 failed**
- frontend: **349 passed / 0 failed** (27 files), `yarn lint` 0 errors, `yarn build` ok
- full solution build: 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PVV1onwwDrwMQXq7fdgRXH

---
_Generated by [Claude Code](https://claude.ai/code/session_01PVV1onwwDrwMQXq7fdgRXH)_